### PR TITLE
Add mock PPO smoke test and explicit task selection for RL env

### DIFF
--- a/docs/iwa_rl_env.md
+++ b/docs/iwa_rl_env.md
@@ -1,0 +1,81 @@
+# IWA Reinforcement Learning Environment
+
+This document summarizes the environment that lives under the [`rl/`](/rl) package. The goal is to keep the design of the OpenAI Gym compatible environment explicit and decouple it from any particular training recipe.
+
+## High-level design
+
+* **Environment class**: [`IWAWebEnv`](../rl/envs/iwa_gym_env.py) implements the Gymnasium API (`reset`, `step`). It only depends on the lightweight [`Browser`](/rl/drivers/browser.py) facade and the [`IWAValidator`](/rl/validator/iwa_evaluator_client.py) adapter.
+* **Executor separation**: the environment expects a `BrowserAdapter` that wraps the actual Playwright/IWA executor. Production miners can inject the adapter that already exists in `autoppia_iwa`, while unit tests can supply mocks. [`ConcurrentExecutorAdapter`](../rl/drivers/concurrent_adapter.py) resolves the concurrent Playwright executor exposed by `AppBootstrap` and converts its snapshots to the normalized `BrowserSnapshot` structure.
+* **Task sourcing**: `IWAValidator.sample_task` is responsible for returning [`TaskSpec`](../rl/envs/types.py). For local experiments you can configure a static `task_pool` inside [`rl/configs/env.yaml`](../rl/configs/env.yaml). When the `autoppia_iwa` stack is available, [`ConcurrentEvaluatorAdapter`](../rl/validator/concurrent_adapter.py) can be referenced from the same config file to reuse the production task repository and concurrent evaluator.
+
+## Action space
+
+The discrete action space is structured as follows (`topk` defaults to 24):
+
+| Segment | Description |
+| ------- | ----------- |
+| `0` | `NOOP` |
+| `1 .. K` | `CLICK_i` – Click the `i`-th ranked DOM element |
+| `K+1 .. 2K` | `FOCUS_i` – Focus the `i`-th ranked DOM element |
+| `2K+0` | `TYPE_CONFIRM` – Type contextual text and press Enter |
+| `2K+1` | `SUBMIT` – Trigger form submission |
+| `2K+2` | `SCROLL_UP` |
+| `2K+3` | `SCROLL_DOWN` |
+| `2K+4` | `BACK` |
+
+The [`Browser`](../rl/drivers/browser.py) exposes capability flags (`can_submit`, `has_focusable_inputs`, `can_scroll`, `can_go_back`), which the environment uses to build an action mask that disables invalid macros. Element level validity is handled by the Top‑K ranker.
+
+## DOM ranking
+
+[`rank_clickables`](../rl/envs/dom_ranker.py) sorts the elements emitted by the browser snapshot. The heuristic uses:
+
+* Visibility / enabled state
+* Role and tag priors (buttons, links, inputs)
+* Similarity between element labels and the task goal
+* Whether the element is in the viewport
+* Text length as a proxy for information density
+
+The function returns both ranked elements and boolean masks indicating whether each entry is safe to click or focus.
+
+## Observation structure
+
+[`ObservationBuilder`](../rl/envs/obs_builders.py) converts the task and browser snapshot into tensors:
+
+* `goal_ids` – hashed tokens (length 64)
+* `dom_ids` – hashed tokens from the visible DOM (length 256)
+* `url_id` – hashed identifier of the current URL
+* `prev_actions` – last 10 discrete actions
+* `topk_meta` – six scalar features per ranked element (role id, clickable, focusable, editable, viewport flag, normalized text length)
+* `topk_text_ids` – hashed tokens of each ranked element’s text (length 12 per element)
+* `inputs_filled_ratio` – fraction of non-empty form fields
+* `cart_items` – numeric cart count from the snapshot
+
+All shapes and vocab sizes are configurable via the `observations` section in [`env.yaml`](../rl/configs/env.yaml).
+
+## Reward shaping
+
+[`RewardComputer`](../rl/envs/rewards.py) combines dense shaping with the external evaluator:
+
+* `+1.0` on success (`validator.evaluate` reports `success=True`)
+* `+0.1` for milestones (URL change, form field filled, cart increase)
+* Optional shaped reward / milestones forwarded by the validator client
+* `−0.001` per step (time cost)
+* `−0.05` for invalid actions and loop penalties
+
+Loop detection is handled inside the environment by tracking repeated signatures over a sliding window (default: 6 steps with a threshold of 3 repeats).
+
+## Configuration entry point
+
+The defaults live in [`rl/configs/env.yaml`](../rl/configs/env.yaml). Override values by passing a dictionary to the environment constructor or by loading the YAML file and passing it as `cfg`.
+
+```python
+from pathlib import Path
+import yaml
+from rl import IWAWebEnv
+
+cfg = yaml.safe_load(Path("rl/configs/env.yaml").read_text())
+env = IWAWebEnv(cfg)
+obs, info = env.reset()
+```
+
+This documentation focuses purely on the environment layer. Training scripts (PPO, BC, etc.) can be added later without modifying the environment contract.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pydantic
 rich
 pytest
 numpy
+gymnasium
 setuptools
 loguru
 xmldiff

--- a/rl/__init__.py
+++ b/rl/__init__.py
@@ -1,0 +1,25 @@
+"""Reinforcement learning environment helpers for Infinite Web Arena (IWA)."""
+
+from typing import Any
+
+from .validator.iwa_evaluator_client import IWAValidator, ValidatorFeedback
+
+_ENV_IMPORT_ERROR: Exception | None = None
+
+try:  # pragma: no cover - optional dependency path
+    from .envs.iwa_gym_env import IWAWebEnv, MacroAction
+except ModuleNotFoundError as exc:  # pragma: no cover - handled lazily
+    IWAWebEnv = None  # type: ignore[assignment]
+    MacroAction = None  # type: ignore[assignment]
+    _ENV_IMPORT_ERROR = exc
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple delegation
+    if name in {"IWAWebEnv", "MacroAction"} and _ENV_IMPORT_ERROR is not None:
+        raise ModuleNotFoundError(
+            "gymnasium is required to instantiate IWAWebEnv; install optional dependency",
+        ) from _ENV_IMPORT_ERROR
+    raise AttributeError(f"module 'rl' has no attribute '{name}'")
+
+
+__all__ = ["IWAWebEnv", "MacroAction", "IWAValidator", "ValidatorFeedback"]

--- a/rl/configs/env.yaml
+++ b/rl/configs/env.yaml
@@ -1,0 +1,40 @@
+# Default configuration for the OpenAI Gym compatible IWA environment.
+# This file documents sane defaults and can be tuned per training run.
+
+topk: 24
+max_steps: 50
+loop_window: 6
+loop_threshold: 3
+
+browser:
+  allow_scroll: true
+  allow_back: true
+  adapter:
+    class: rl.drivers.concurrent_adapter.ConcurrentExecutorAdapter
+    kwargs: {}
+
+observations:
+  goal_vocab_size: 4096
+  dom_vocab_size: 8192
+  url_vocab_size: 1024
+  max_goal_tokens: 64
+  max_dom_tokens: 256
+  max_element_tokens: 12
+  action_history: 10
+  topk_meta_dim: 6
+  max_cart_items: 10
+
+rewards:
+  success_reward: 1.0
+  milestone_reward: 0.1
+  step_penalty: 0.001
+  invalid_action_penalty: 0.05
+  loop_penalty: 0.05
+
+validator:
+  # task_pool can be used during local development when the remote validator is
+  # unavailable. Each entry must provide task_id, demo_web_id and goal.
+  task_pool: []
+  client:
+    class: rl.validator.concurrent_adapter.ConcurrentEvaluatorAdapter
+    kwargs: {}

--- a/rl/drivers/__init__.py
+++ b/rl/drivers/__init__.py
@@ -1,0 +1,6 @@
+"""Browser drivers and adapters for the IWA RL environment."""
+
+from .browser import Browser, BrowserAdapter
+from .concurrent_adapter import ConcurrentExecutorAdapter
+
+__all__ = ["Browser", "BrowserAdapter", "ConcurrentExecutorAdapter"]

--- a/rl/drivers/browser.py
+++ b/rl/drivers/browser.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import logging
+from typing import Mapping, Optional, Protocol
+
+from ..envs.types import BrowserSnapshot, ElementMetadata
+from ..utils import load_object
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserAdapter(Protocol):
+    """Protocol that concrete IWA executors must implement.
+
+    The adapter isolates the RL environment from the concrete Playwright based
+    executor shipped in the `autoppia_iwa` module.  The goal is to make it
+    possible to mock the browser in unit tests while keeping the production
+    adapter thin.
+    """
+
+    def reset(self, demo_web_id: str) -> BrowserSnapshot:
+        ...
+
+    def snapshot(self) -> BrowserSnapshot:
+        ...
+
+    def click(self, element_id: str) -> BrowserSnapshot:
+        ...
+
+    def focus(self, element_id: str) -> BrowserSnapshot:
+        ...
+
+    def type_and_confirm(self, text: str) -> BrowserSnapshot:
+        ...
+
+    def submit(self) -> BrowserSnapshot:
+        ...
+
+    def scroll(self, direction: str) -> BrowserSnapshot:
+        ...
+
+    def back(self) -> BrowserSnapshot:
+        ...
+
+
+class Browser:
+    """Stateful façade over the low-level executor.
+
+    The instance maintains the latest :class:`BrowserSnapshot` and exposes
+    higher level helpers used by the environment to build observations, compute
+    rewards and masks.
+    """
+
+    def __init__(
+        self,
+        config: Optional[Mapping[str, object]] = None,
+        adapter: Optional[BrowserAdapter] = None,
+    ) -> None:
+        self._config = dict(config or {})
+        if adapter is None:
+            adapter_cfg = dict(self._config.get("adapter") or {})
+            adapter = self._load_adapter_from_config(adapter_cfg)
+        self._adapter = adapter
+        self._snapshot = BrowserSnapshot(url="", dom_text="", elements=[])
+
+    # ------------------------------------------------------------------
+    # Snapshot helpers
+    # ------------------------------------------------------------------
+    @property
+    def snapshot(self) -> BrowserSnapshot:
+        return self._snapshot
+
+    def refresh(self) -> BrowserSnapshot:
+        if self._adapter is None:
+            raise RuntimeError("Browser adapter not configured")
+        self._snapshot = self._adapter.snapshot()
+        return self._snapshot
+
+    def reset_to_demo(self, demo_web_id: str) -> BrowserSnapshot:
+        if self._adapter is None:
+            raise RuntimeError("Browser adapter not configured")
+        self._snapshot = self._adapter.reset(demo_web_id)
+        return self._snapshot
+
+    def _load_adapter_from_config(self, adapter_cfg: Mapping[str, object]) -> Optional[BrowserAdapter]:
+        if not adapter_cfg:
+            return None
+
+        entrypoint = adapter_cfg.get("class") or adapter_cfg.get("entrypoint")
+        if not entrypoint:
+            raise ValueError("Browser adapter configuration must include 'class' or 'entrypoint'")
+
+        try:
+            adapter_cls = load_object(str(entrypoint))
+        except (ImportError, AttributeError) as exc:
+            logger.warning("Failed to import browser adapter '%s': %s", entrypoint, exc)
+            return None
+        kwargs = dict(adapter_cfg.get("kwargs") or {})
+        return adapter_cls(**kwargs)
+
+    # ------------------------------------------------------------------
+    # DOM Queries
+    # ------------------------------------------------------------------
+    def get_visible_elements(self) -> list[ElementMetadata]:
+        return list(self._snapshot.elements)
+
+    def get_dom_text(self) -> str:
+        return self._snapshot.dom_text
+
+    def get_url(self) -> str:
+        return self._snapshot.url
+
+    def get_inputs_state(self) -> Mapping[str, str]:
+        return dict(self._snapshot.inputs_state.values)
+
+    # ------------------------------------------------------------------
+    # Capability flags used for action masking
+    # ------------------------------------------------------------------
+    def can_submit(self) -> bool:
+        return any(
+            el.clickable
+            and el.is_visible
+            and el.is_enabled
+            and (el.role in {"button", "link", "submit"} or el.tag in {"button", "a", "input"})
+            for el in self._snapshot.elements
+        )
+
+    def has_focusable_inputs(self) -> bool:
+        return any(el.focusable and el.is_enabled and el.is_visible for el in self._snapshot.elements)
+
+    def can_scroll(self) -> bool:
+        # Assume scrolling is always possible unless explicitly disabled via config
+        return bool(self._config.get("allow_scroll", True))
+
+    def can_go_back(self) -> bool:
+        metadata_flag = self._snapshot.metadata.get("can_go_back")
+        if isinstance(metadata_flag, bool):
+            return metadata_flag
+        return bool(self._config.get("allow_back", True))
+
+    # ------------------------------------------------------------------
+    # Action primitives (delegate to adapter)
+    # ------------------------------------------------------------------
+    def click(self, element: ElementMetadata) -> BrowserSnapshot:
+        if self._adapter is None:
+            raise RuntimeError("Browser adapter not configured")
+        logger.debug("Browser.click -> %s", element.element_id)
+        self._snapshot = self._adapter.click(element.element_id)
+        return self._snapshot
+
+    def focus(self, element: ElementMetadata) -> BrowserSnapshot:
+        if self._adapter is None:
+            raise RuntimeError("Browser adapter not configured")
+        logger.debug("Browser.focus -> %s", element.element_id)
+        self._snapshot = self._adapter.focus(element.element_id)
+        return self._snapshot
+
+    def type_confirm(self, text: str) -> BrowserSnapshot:
+        if self._adapter is None:
+            raise RuntimeError("Browser adapter not configured")
+        logger.debug("Browser.type_confirm -> %s", text)
+        self._snapshot = self._adapter.type_and_confirm(text)
+        return self._snapshot
+
+    def submit(self) -> BrowserSnapshot:
+        if self._adapter is None:
+            raise RuntimeError("Browser adapter not configured")
+        logger.debug("Browser.submit")
+        self._snapshot = self._adapter.submit()
+        return self._snapshot
+
+    def scroll(self, direction: str) -> BrowserSnapshot:
+        if self._adapter is None:
+            raise RuntimeError("Browser adapter not configured")
+        if direction not in {"up", "down"}:
+            raise ValueError(f"Unsupported scroll direction: {direction}")
+        logger.debug("Browser.scroll -> %s", direction)
+        self._snapshot = self._adapter.scroll(direction)
+        return self._snapshot
+
+    def back(self) -> BrowserSnapshot:
+        if self._adapter is None:
+            raise RuntimeError("Browser adapter not configured")
+        logger.debug("Browser.back")
+        self._snapshot = self._adapter.back()
+        return self._snapshot
+
+
+__all__ = ["Browser", "BrowserAdapter"]

--- a/rl/drivers/concurrent_adapter.py
+++ b/rl/drivers/concurrent_adapter.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+"""Adapters that connect the RL browser facade with the IWA executor stack."""
+
+import inspect
+import logging
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+from ..envs.types import (
+    BrowserInputsState,
+    BrowserSnapshot,
+    ElementMetadata,
+)
+from .browser import BrowserAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class ConcurrentExecutorAdapter(BrowserAdapter):
+    """Wrap the concurrent Playwright executor shipped with IWA.
+
+    The adapter resolves the executor lazily via :class:`autoppia_iwa.src.bootstrap.AppBootstrap`
+    so that the environment can run inside miners, validators or standalone
+    scripts without manually wiring dependencies.  Because the upstream API is
+    subject to change, the adapter performs defensive attribute lookups and
+    accepts pre-instantiated executors via ``executor=``.
+    """
+
+    def __init__(
+        self,
+        *,
+        executor: Optional[Any] = None,
+        bootstrap_kwargs: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self._bootstrap_kwargs = dict(bootstrap_kwargs or {})
+        self._executor = executor or self._resolve_executor()
+        if self._executor is None:
+            raise RuntimeError(
+                "ConcurrentExecutorAdapter could not locate a Playwright executor. "
+                "Ensure autoppia_iwa is installed and AppBootstrap provides one."
+            )
+        self._snapshot: Optional[BrowserSnapshot] = None
+
+    # ------------------------------------------------------------------
+    # BrowserAdapter protocol
+    # ------------------------------------------------------------------
+    def reset(self, demo_web_id: str) -> BrowserSnapshot:
+        self._call_executor(["reset_to_demo", "reset"], demo_web_id)
+        return self.snapshot()
+
+    def snapshot(self) -> BrowserSnapshot:
+        state = self._call_executor(
+            ["snapshot", "get_snapshot", "current_state", "state", "get_state"]
+        )
+        self._snapshot = self._coerce_snapshot(state)
+        return self._snapshot
+
+    def click(self, element_id: str) -> BrowserSnapshot:
+        self._call_executor(["click", "click_element", "perform_click"], element_id)
+        return self.snapshot()
+
+    def focus(self, element_id: str) -> BrowserSnapshot:
+        self._call_executor(["focus", "focus_element", "perform_focus"], element_id)
+        return self.snapshot()
+
+    def type_and_confirm(self, text: str) -> BrowserSnapshot:
+        self._call_executor(
+            ["type_and_confirm", "type_and_submit", "type", "enter_text"], text
+        )
+        return self.snapshot()
+
+    def submit(self) -> BrowserSnapshot:
+        self._call_executor(["submit", "press_submit", "trigger_submit"])
+        return self.snapshot()
+
+    def scroll(self, direction: str) -> BrowserSnapshot:
+        self._call_executor(["scroll", "perform_scroll", "scroll_page"], direction)
+        return self.snapshot()
+
+    def back(self) -> BrowserSnapshot:
+        self._call_executor(["back", "go_back", "navigate_back"])
+        return self.snapshot()
+
+    # ------------------------------------------------------------------
+    # Executor helpers
+    # ------------------------------------------------------------------
+    def _resolve_executor(self) -> Optional[Any]:
+        try:
+            from autoppia_iwa.src.bootstrap import AppBootstrap  # type: ignore
+        except Exception as exc:  # pragma: no cover - requires optional dependency
+            logger.warning("Failed to import AppBootstrap: %s", exc)
+            return None
+
+        bootstrap = AppBootstrap(**self._bootstrap_kwargs)
+        candidates: Sequence[str] = (
+            "concurrent_executor",
+            "executor",
+            "web_executor",
+            "browser_executor",
+        )
+
+        for attr in candidates:
+            executor = getattr(bootstrap, attr, None)
+            if executor is not None:
+                return executor
+
+        container = getattr(bootstrap, "di_container", None)
+        if container is not None:
+            for key in (
+                "concurrent_executor",
+                "browser_executor",
+                "web_executor",
+            ):
+                try:
+                    executor = container.resolve(key)  # type: ignore[attr-defined]
+                    if executor is not None:
+                        return executor
+                except Exception:  # pragma: no cover - optional dependency
+                    continue
+        return None
+
+    def _call_executor(self, method_candidates: Iterable[str], *args: Any) -> Any:
+        for name in method_candidates:
+            method = getattr(self._executor, name, None)
+            if callable(method):
+                return method(*args)
+        raise AttributeError(
+            f"Executor {type(self._executor)!r} does not expose any of {list(method_candidates)}"
+        )
+
+    # ------------------------------------------------------------------
+    # Coercion helpers
+    # ------------------------------------------------------------------
+    def _coerce_snapshot(self, state: Any) -> BrowserSnapshot:
+        if isinstance(state, BrowserSnapshot):
+            return state
+
+        if state is None and self._snapshot is not None:
+            return self._snapshot
+
+        if state is None:
+            raise RuntimeError("Executor returned None snapshot; cannot proceed")
+
+        url = self._first_attr(state, ["url", "current_url", "page_url"], default="")
+        dom_text = self._first_attr(
+            state,
+            [
+                "dom_text",
+                "text",
+                "visible_text",
+                "page_text",
+            ],
+            default="",
+        )
+        elements = self._coerce_elements(
+            self._first_attr(state, ["elements", "visible_elements", "nodes"], default=[])
+        )
+        inputs_raw = self._first_attr(
+            state,
+            ["inputs_state", "inputs", "form_values", "input_values"],
+            default={},
+        )
+        cart_items = self._first_attr(state, ["cart_items", "cart_count"], default=0)
+        metadata = self._coerce_mapping(
+            self._first_attr(state, ["metadata", "meta", "extra"], default={})
+        )
+
+        inputs_state = (
+            inputs_raw
+            if isinstance(inputs_raw, BrowserInputsState)
+            else BrowserInputsState(values=self._coerce_mapping(inputs_raw))
+        )
+
+        snapshot = BrowserSnapshot(
+            url=str(url or ""),
+            dom_text=str(dom_text or ""),
+            elements=elements,
+            inputs_state=inputs_state,
+            cart_items=int(cart_items or 0),
+            metadata=metadata,
+        )
+        self._snapshot = snapshot
+        return snapshot
+
+    def _coerce_elements(self, raw_elements: Any) -> list[ElementMetadata]:
+        elements: list[ElementMetadata] = []
+        if raw_elements is None:
+            return elements
+
+        if isinstance(raw_elements, Mapping):
+            raw_iterable = raw_elements.values()
+        elif isinstance(raw_elements, Sequence) and not isinstance(raw_elements, (str, bytes)):
+            raw_iterable = raw_elements
+        else:
+            raw_iterable = [raw_elements]
+
+        for raw in raw_iterable:
+            if isinstance(raw, ElementMetadata):
+                elements.append(raw)
+                continue
+            if raw is None:
+                continue
+            element_id = self._first_attr(
+                raw,
+                ["element_id", "id", "node_id", "handle"],
+                default="",
+            )
+            role = self._first_attr(raw, ["role", "aria_role", "node_role"], default=None)
+            tag = self._first_attr(raw, ["tag", "tag_name", "node_name"], default=None)
+            text = self._first_attr(
+                raw,
+                [
+                    "text",
+                    "inner_text",
+                    "innerText",
+                    "label",
+                    "value",
+                ],
+                default="",
+            )
+            aria_label = self._first_attr(
+                raw,
+                ["aria_label", "ariaLabel", "label"],
+                default=None,
+            )
+            placeholder = self._first_attr(raw, ["placeholder"], default=None)
+            input_type = self._first_attr(
+                raw,
+                ["input_type", "type"],
+                default=None,
+            )
+            bounding_box = self._first_attr(
+                raw,
+                ["bounding_box", "bbox", "boundingBox"],
+                default=None,
+            )
+
+            extra = self._coerce_mapping(self._first_attr(raw, ["extra", "metadata"], default={}))
+
+            def truthy(keys: Sequence[str], default: bool = False) -> bool:
+                for key in keys:
+                    value = getattr(raw, key, None)
+                    if value is None and isinstance(raw, Mapping):
+                        value = raw.get(key)
+                    if value is not None:
+                        return bool(value)
+                return default
+
+            elements.append(
+                ElementMetadata(
+                    element_id=str(element_id or ""),
+                    role=str(role) if role is not None else None,
+                    tag=str(tag) if tag is not None else None,
+                    text=str(text or ""),
+                    aria_label=str(aria_label) if aria_label else None,
+                    placeholder=str(placeholder) if placeholder else None,
+                    input_type=str(input_type) if input_type else None,
+                    clickable=truthy(["clickable", "is_clickable", "can_click"], False),
+                    focusable=truthy(["focusable", "is_focusable", "can_focus"], False),
+                    editable=truthy(["editable", "is_editable", "can_type"], False),
+                    is_visible=truthy(["is_visible", "visible"], True),
+                    is_enabled=truthy(["is_enabled", "enabled", "can_interact"], True),
+                    is_in_viewport=truthy(["is_in_viewport", "in_viewport", "within_viewport"], True),
+                    bounding_box=bounding_box,
+                    extra=extra,
+                )
+            )
+        return elements
+
+    @staticmethod
+    def _coerce_mapping(raw: Any) -> Dict[str, Any]:
+        if isinstance(raw, MutableMapping):
+            return dict(raw)
+        if hasattr(raw, "items"):
+            return dict(raw.items())
+        if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes)):
+            result: Dict[str, Any] = {}
+            for item in raw:
+                if isinstance(item, Mapping):
+                    result.update(item)
+            return result
+        return {}
+
+    @staticmethod
+    def _first_attr(obj: Any, names: Sequence[str], default: Any) -> Any:
+        for name in names:
+            if hasattr(obj, name):
+                value = getattr(obj, name)
+                if inspect.ismethod(value):
+                    try:
+                        return value()
+                    except Exception:  # pragma: no cover - best effort
+                        continue
+                return value
+            if isinstance(obj, Mapping) and name in obj:
+                return obj[name]
+        return default
+
+
+__all__ = ["ConcurrentExecutorAdapter"]
+

--- a/rl/envs/__init__.py
+++ b/rl/envs/__init__.py
@@ -1,0 +1,52 @@
+"""Environment building blocks for the IWA RL stack."""
+
+from typing import Any
+
+from .dom_ranker import rank_clickables
+from .obs_builders import ObservationBuilder
+from .rewards import RewardComputer, RewardConfig
+from .types import (
+    ActionResult,
+    BrowserInputsState,
+    BrowserSnapshot,
+    ElementMetadata,
+    RankResult,
+    RankedElement,
+    RewardSignal,
+    TaskSpec,
+)
+
+_ENV_IMPORT_ERROR: Exception | None = None
+
+try:  # pragma: no cover - optional dependency path
+    from .iwa_gym_env import IWAWebEnv, MacroAction
+except ModuleNotFoundError as exc:  # pragma: no cover - handled lazily
+    IWAWebEnv = None  # type: ignore[assignment]
+    MacroAction = None  # type: ignore[assignment]
+    _ENV_IMPORT_ERROR = exc
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple delegation
+    if name in {"IWAWebEnv", "MacroAction"} and _ENV_IMPORT_ERROR is not None:
+        raise ModuleNotFoundError(
+            "gymnasium is required to instantiate IWAWebEnv; install optional dependency",
+        ) from _ENV_IMPORT_ERROR
+    raise AttributeError(f"module 'rl.envs' has no attribute '{name}'")
+
+
+__all__ = [
+    "IWAWebEnv",
+    "MacroAction",
+    "ObservationBuilder",
+    "rank_clickables",
+    "RewardComputer",
+    "RewardConfig",
+    "ActionResult",
+    "BrowserInputsState",
+    "BrowserSnapshot",
+    "ElementMetadata",
+    "RankResult",
+    "RankedElement",
+    "RewardSignal",
+    "TaskSpec",
+]

--- a/rl/envs/dom_ranker.py
+++ b/rl/envs/dom_ranker.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import math
+import re
+from typing import Iterable, List, Sequence
+
+from .types import ElementMetadata, RankResult, RankedElement, TaskSpec
+
+_ROLE_PRIORITY = {
+    "button": 1.0,
+    "link": 0.9,
+    "submit": 0.95,
+    "textbox": 0.8,
+    "combobox": 0.75,
+    "listbox": 0.7,
+    "menuitem": 0.65,
+}
+
+_ROLE_TO_ID = {role: idx + 1 for idx, role in enumerate(sorted(_ROLE_PRIORITY))}
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip().lower()
+
+
+def _tokenize(text: str) -> List[str]:
+    normalized = _normalize(text)
+    return [token for token in re.split(r"[^\w]+", normalized) if token]
+
+
+def _similarity(candidate_tokens: Sequence[str], goal_tokens: Sequence[str]) -> float:
+    if not candidate_tokens or not goal_tokens:
+        return 0.0
+    goal_set = set(goal_tokens)
+    overlap = sum(1 for token in candidate_tokens if token in goal_set)
+    return overlap / math.sqrt(len(goal_tokens) * len(candidate_tokens))
+
+
+def _element_score(element: ElementMetadata, goal_tokens: Sequence[str]) -> float:
+    score = 0.0
+    if not element.is_visible or not element.is_enabled:
+        return score
+
+    if element.clickable:
+        score += 1.0
+    if element.focusable:
+        score += 0.3
+    if element.editable:
+        score += 0.2
+
+    role_bonus = _ROLE_PRIORITY.get((element.role or "").lower())
+    if role_bonus:
+        score += role_bonus
+
+    label_tokens: List[str] = []
+    for label in element.label_candidates():
+        label_tokens.extend(_tokenize(label))
+    score += 1.25 * _similarity(label_tokens, goal_tokens)
+
+    if element.is_in_viewport:
+        score += 0.1
+    if element.tag in {"input", "textarea"}:
+        score += 0.2
+
+    return score
+
+
+def rank_clickables(
+    elements: Iterable[ElementMetadata],
+    task: TaskSpec,
+    top_k: int,
+) -> RankResult:
+    """Rank actionable elements and return Top-K along with masks.
+
+    Parameters
+    ----------
+    elements:
+        Iterable of :class:`ElementMetadata` describing the DOM snapshot.
+    task:
+        The current :class:`TaskSpec`.  Only the goal text is used for now but the
+        signature allows richer heuristics later on.
+    top_k:
+        Number of elements to keep.
+    """
+
+    goal_tokens = _tokenize(task.goal)
+    ranked: List[RankedElement] = []
+
+    for element in elements:
+        score = _element_score(element, goal_tokens)
+        if score <= 0:
+            continue
+        meta_features = (
+            float(_ROLE_TO_ID.get((element.role or "").lower(), 0)) / max(len(_ROLE_TO_ID), 1),
+            1.0 if element.clickable else 0.0,
+            1.0 if element.focusable else 0.0,
+            1.0 if element.editable else 0.0,
+            1.0 if element.is_in_viewport else 0.0,
+            min(len(_tokenize(element.text)), 64) / 64.0,
+        )
+        ranked.append(
+            RankedElement(
+                element=element,
+                score=score,
+                meta_features=meta_features,
+            )
+        )
+
+    ranked.sort(key=lambda item: item.score, reverse=True)
+    ranked = ranked[:top_k]
+    click_mask: List[bool] = [
+        bool(item.element.clickable and item.element.is_visible and item.element.is_enabled)
+        for item in ranked
+    ]
+    focus_mask: List[bool] = [
+        bool(item.element.focusable and item.element.is_visible and item.element.is_enabled)
+        for item in ranked
+    ]
+
+    return RankResult(elements=ranked, click_mask=click_mask, focus_mask=focus_mask)
+
+
+__all__ = ["rank_clickables"]

--- a/rl/envs/iwa_gym_env.py
+++ b/rl/envs/iwa_gym_env.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import enum
+import random
+from collections import Counter, deque
+from typing import Deque, Mapping, Optional
+
+import gymnasium as gym
+import numpy as np
+from gymnasium import spaces
+
+from .dom_ranker import rank_clickables
+from .obs_builders import ObservationBuilder
+from .rewards import RewardComputer
+from .types import ActionResult, BrowserSnapshot, RankResult, TaskSpec
+from ..drivers.browser import Browser
+from ..validator.iwa_evaluator_client import IWAValidator
+
+
+class MacroAction(enum.IntEnum):
+    TYPE_CONFIRM = 0
+    SUBMIT = 1
+    SCROLL_UP = 2
+    SCROLL_DOWN = 3
+    BACK = 4
+
+
+class IWAWebEnv(gym.Env):
+    metadata = {"render_modes": ["human"]}
+
+    def __init__(
+        self,
+        cfg: Optional[Mapping[str, object]] = None,
+        *,
+        browser: Optional[Browser] = None,
+        validator: Optional[IWAValidator] = None,
+    ) -> None:
+        super().__init__()
+        self.cfg = dict(cfg or {})
+        self.K = int(self.cfg.get("topk", 24))
+        self.max_steps = int(self.cfg.get("max_steps", 50))
+        self.loop_window = int(self.cfg.get("loop_window", 6))
+        self.loop_threshold = int(self.cfg.get("loop_threshold", 3))
+
+        obs_cfg = dict(self.cfg.get("observations") or {})
+        reward_cfg = dict(self.cfg.get("rewards") or {})
+        validator_cfg = dict(self.cfg.get("validator") or {})
+        browser_cfg = dict(self.cfg.get("browser") or {})
+
+        if browser is None:
+            browser = Browser(config=browser_cfg)
+        self.browser = browser
+
+        self.validator = validator or IWAValidator(config=validator_cfg)
+        self.reward_computer = RewardComputer(config=reward_cfg, validator=self.validator)
+        self.observation_builder = ObservationBuilder(obs_cfg)
+
+        self.action_history: Deque[int] = deque(maxlen=self.observation_builder.history_length)
+        self.recent_signatures: Deque[str] = deque(maxlen=self.loop_window)
+
+        self.task: Optional[TaskSpec] = None
+        self.previous_snapshot: Optional[BrowserSnapshot] = None
+        self.snapshot: Optional[BrowserSnapshot] = None
+        self.rank: RankResult = RankResult(elements=[], click_mask=[], focus_mask=[])
+        self.step_count = 0
+
+        # Action space layout: [NOOP] + [CLICK_K] + [FOCUS_K] + macros
+        self.action_offset_click = 1
+        self.action_offset_focus = self.action_offset_click + self.K
+        self.action_offset_macros = self.action_offset_focus + self.K
+        self.action_space = spaces.Discrete(self.action_offset_macros + len(MacroAction))
+        self.observation_space = self.observation_builder.space(self.action_space.n, self.K)
+
+    # ------------------------------------------------------------------
+    # Gym API
+    # ------------------------------------------------------------------
+    def reset(self, *, seed: Optional[int] = None, options: Optional[Mapping[str, object]] = None):
+        super().reset(seed=seed)
+        options = options or {}
+        self.task = self._sample_task(options)
+        self.browser.reset_to_demo(self.task.demo_web_id)
+        self.snapshot = self.browser.snapshot
+        self.previous_snapshot = None
+        self.rank = rank_clickables(self.snapshot.elements, self.task, self.K)
+        self.action_history.clear()
+        self.recent_signatures.clear()
+        self.step_count = 0
+
+        obs = self._build_observation()
+        info = {"task_id": self.task.task_id, "action_mask": self._action_mask()}
+        return obs, info
+
+    def step(self, action: int):
+        if self.task is None or self.snapshot is None:
+            raise RuntimeError("Environment must be reset before stepping")
+
+        self.step_count += 1
+        action = int(action)
+        self.action_history.append(action)
+
+        action_result = self._apply_action(action)
+        self.previous_snapshot = self.snapshot
+        self.snapshot = self.browser.snapshot
+        self.rank = rank_clickables(self.snapshot.elements, self.task, self.K)
+
+        loop_penalty = self._register_signature(action_result.signature)
+        reward_signal = self.reward_computer.compute(
+            task=self.task,
+            previous=self.previous_snapshot,
+            current=self.snapshot,
+            invalid_action=action_result.invalid,
+            loop_penalty=loop_penalty,
+        )
+
+        terminated = bool(reward_signal.success or reward_signal.invalid_episode)
+        truncated = bool(self.step_count >= self.max_steps)
+        obs = self._build_observation()
+        info = {
+            "success": reward_signal.success,
+            "milestones": reward_signal.milestones,
+            "action_mask": self._action_mask(),
+            "invalid_action": action_result.invalid,
+        }
+
+        return obs, reward_signal.reward, terminated, truncated, info
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _build_observation(self):
+        if self.task is None or self.snapshot is None:
+            raise RuntimeError("Observation requested without an active task")
+        return self.observation_builder.build(
+            task=self.task,
+            snapshot=self.snapshot,
+            rank=self.rank,
+            action_history=self.action_history,
+            top_k=self.K,
+        )
+
+    def _sample_task(self, options: Mapping[str, object]) -> TaskSpec:
+        if options:
+            if "task" in options:
+                return self._coerce_task_spec(options["task"])
+            if "task_spec" in options:
+                return self._coerce_task_spec(options["task_spec"])
+
+        options = dict(options or {})
+        if "index" not in options:
+            options["index"] = random.randint(0, 10_000)
+        return self.validator.sample_task(options)
+
+    @staticmethod
+    def _coerce_task_spec(value: object) -> TaskSpec:
+        if isinstance(value, TaskSpec):
+            return value
+        if isinstance(value, Mapping):
+            mapping = value
+            try:
+                task_id = str(mapping["task_id"])
+                demo_web_id = str(mapping["demo_web_id"])
+                goal = str(mapping["goal"])
+            except KeyError as exc:  # pragma: no cover - defensive, validated by tests
+                raise ValueError("Task specification mapping must include task_id, demo_web_id and goal") from exc
+            metadata = dict(mapping.get("metadata") or {})
+            return TaskSpec(task_id=task_id, demo_web_id=demo_web_id, goal=goal, metadata=metadata)
+        raise TypeError(
+            "Task specification must be a TaskSpec instance or a mapping with task_id/demo_web_id/goal"
+        )
+
+    def _register_signature(self, signature: str) -> bool:
+        if not signature:
+            return False
+        self.recent_signatures.append(signature)
+        counts = Counter(self.recent_signatures)
+        return counts[signature] >= self.loop_threshold
+
+    def _apply_action(self, action: int) -> ActionResult:
+        if action == 0:
+            return ActionResult(invalid=False, description="noop", signature="noop")
+
+        if self.rank is None:
+            raise RuntimeError("Rank is not initialized")
+
+        if self.action_offset_click <= action < self.action_offset_focus:
+            idx = action - self.action_offset_click
+            element = self._element_from_rank(idx)
+            if element is None or not element.clickable:
+                return ActionResult(invalid=True, description="invalid_click", signature=f"click:{idx}")
+            self.browser.click(element)
+            return ActionResult(invalid=False, description="click", signature=f"click:{element.element_id}")
+
+        if self.action_offset_focus <= action < self.action_offset_macros:
+            idx = action - self.action_offset_focus
+            element = self._element_from_rank(idx)
+            if element is None or not element.focusable:
+                return ActionResult(invalid=True, description="invalid_focus", signature=f"focus:{idx}")
+            self.browser.focus(element)
+            return ActionResult(invalid=False, description="focus", signature=f"focus:{element.element_id}")
+
+        macro_index = action - self.action_offset_macros
+        try:
+            macro = MacroAction(macro_index)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported macro action index: {macro_index}") from exc
+        if macro is MacroAction.TYPE_CONFIRM:
+            text = self._text_to_type()
+            if not text:
+                return ActionResult(invalid=True, description="empty_type", signature="type")
+            self.browser.type_confirm(text)
+            return ActionResult(invalid=False, description="type_confirm", signature="type")
+        if macro is MacroAction.SUBMIT:
+            if not self.browser.can_submit():
+                return ActionResult(invalid=True, description="invalid_submit", signature="submit")
+            self.browser.submit()
+            return ActionResult(invalid=False, description="submit", signature="submit")
+        if macro is MacroAction.SCROLL_UP:
+            if not self.browser.can_scroll():
+                return ActionResult(invalid=True, description="invalid_scroll_up", signature="scroll_up")
+            self.browser.scroll("up")
+            return ActionResult(invalid=False, description="scroll_up", signature="scroll_up")
+        if macro is MacroAction.SCROLL_DOWN:
+            if not self.browser.can_scroll():
+                return ActionResult(invalid=True, description="invalid_scroll_down", signature="scroll_down")
+            self.browser.scroll("down")
+            return ActionResult(invalid=False, description="scroll_down", signature="scroll_down")
+        if macro is MacroAction.BACK:
+            if not self.browser.can_go_back():
+                return ActionResult(invalid=True, description="invalid_back", signature="back")
+            self.browser.back()
+            return ActionResult(invalid=False, description="back", signature="back")
+
+        raise ValueError(f"Unsupported action index: {action}")
+
+    def _element_from_rank(self, idx: int):
+        if idx < 0 or idx >= len(self.rank.elements):
+            return None
+        return self.rank.elements[idx].element
+
+    def _text_to_type(self) -> str:
+        if self.task is None:
+            return ""
+        metadata = self.task.metadata or {}
+        if "type_text" in metadata:
+            return str(metadata["type_text"])
+        return self.task.goal
+
+    def _action_mask(self) -> np.ndarray:
+        mask = np.zeros(self.action_space.n, dtype=np.bool_)
+        mask[0] = True  # NOOP is always allowed
+
+        for idx in range(self.K):
+            click_allowed = idx < len(self.rank.click_mask) and bool(self.rank.click_mask[idx])
+            focus_allowed = idx < len(self.rank.focus_mask) and bool(self.rank.focus_mask[idx])
+            mask[self.action_offset_click + idx] = click_allowed
+            mask[self.action_offset_focus + idx] = focus_allowed
+
+        mask[self.action_offset_macros + MacroAction.TYPE_CONFIRM] = self.browser.has_focusable_inputs()
+        mask[self.action_offset_macros + MacroAction.SUBMIT] = self.browser.can_submit()
+        mask[self.action_offset_macros + MacroAction.SCROLL_UP] = self.browser.can_scroll()
+        mask[self.action_offset_macros + MacroAction.SCROLL_DOWN] = self.browser.can_scroll()
+        mask[self.action_offset_macros + MacroAction.BACK] = self.browser.can_go_back()
+        return mask
+
+
+__all__ = ["IWAWebEnv", "MacroAction"]

--- a/rl/envs/obs_builders.py
+++ b/rl/envs/obs_builders.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Deque, Iterable, List
+
+import numpy as np
+from gymnasium import spaces
+
+from .types import BrowserSnapshot, RankResult, TaskSpec
+
+
+def _tokenize(text: str) -> List[str]:
+    normalized = re.sub(r"\s+", " ", text or "").strip().lower()
+    return [token for token in re.split(r"[^\w]+", normalized) if token]
+
+
+class ObservationBuilder:
+    """Transforms browser and task state into PPO friendly tensors."""
+
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self.goal_vocab = int(cfg.get("goal_vocab_size", 4096))
+        self.dom_vocab = int(cfg.get("dom_vocab_size", 8192))
+        self.url_vocab = int(cfg.get("url_vocab_size", 1024))
+        self.max_goal_tokens = int(cfg.get("max_goal_tokens", 64))
+        self.max_dom_tokens = int(cfg.get("max_dom_tokens", 256))
+        self.max_element_tokens = int(cfg.get("max_element_tokens", 12))
+        self.history_length = int(cfg.get("action_history", 10))
+        self.topk_meta_dim = int(cfg.get("topk_meta_dim", 6))
+        self.max_cart_items = float(cfg.get("max_cart_items", 10.0))
+
+    # ------------------------------------------------------------------
+    # Gym spaces
+    # ------------------------------------------------------------------
+    def space(self, action_space_n: int, top_k: int) -> spaces.Dict:
+        return spaces.Dict(
+            {
+                "goal_ids": spaces.Box(
+                    low=0,
+                    high=self.goal_vocab,
+                    shape=(self.max_goal_tokens,),
+                    dtype=np.int32,
+                ),
+                "dom_ids": spaces.Box(
+                    low=0,
+                    high=self.dom_vocab,
+                    shape=(self.max_dom_tokens,),
+                    dtype=np.int32,
+                ),
+                "url_id": spaces.Box(low=0, high=self.url_vocab, shape=(1,), dtype=np.int32),
+                "prev_actions": spaces.Box(
+                    low=0,
+                    high=action_space_n,
+                    shape=(self.history_length,),
+                    dtype=np.int32,
+                ),
+                "topk_meta": spaces.Box(
+                    low=0.0,
+                    high=1.0,
+                    shape=(top_k, self.topk_meta_dim),
+                    dtype=np.float32,
+                ),
+                "topk_text_ids": spaces.Box(
+                    low=0,
+                    high=self.dom_vocab,
+                    shape=(top_k, self.max_element_tokens),
+                    dtype=np.int32,
+                ),
+                "inputs_filled_ratio": spaces.Box(
+                    low=0.0,
+                    high=1.0,
+                    shape=(1,),
+                    dtype=np.float32,
+                ),
+                "cart_items": spaces.Box(
+                    low=0.0,
+                    high=self.max_cart_items,
+                    shape=(1,),
+                    dtype=np.float32,
+                ),
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Encoding helpers
+    # ------------------------------------------------------------------
+    def _hash_token(self, token: str, vocab: int) -> int:
+        digest = hashlib.blake2b(token.encode("utf-8"), digest_size=4).digest()
+        return int.from_bytes(digest, "little") % vocab
+
+    def _encode_tokens(self, tokens: Iterable[str], limit: int, vocab: int) -> np.ndarray:
+        arr = np.zeros((limit,), dtype=np.int32)
+        for idx, token in enumerate(tokens):
+            if idx >= limit:
+                break
+            arr[idx] = self._hash_token(token, vocab)
+        return arr
+
+    def _encode_text(self, text: str, limit: int, vocab: int) -> np.ndarray:
+        return self._encode_tokens(_tokenize(text), limit, vocab)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build(
+        self,
+        task: TaskSpec,
+        snapshot: BrowserSnapshot,
+        rank: RankResult,
+        action_history: Deque[int],
+        top_k: int,
+    ) -> dict:
+        obs = {
+            "goal_ids": self._encode_text(task.goal, self.max_goal_tokens, self.goal_vocab),
+            "dom_ids": self._encode_text(snapshot.dom_text, self.max_dom_tokens, self.dom_vocab),
+            "url_id": np.array(
+                [self._hash_token(snapshot.url or "", self.url_vocab)], dtype=np.int32
+            ),
+            "prev_actions": self._encode_history(action_history),
+            "topk_meta": self._encode_meta(rank, top_k),
+            "topk_text_ids": self._encode_topk_text(rank, top_k),
+            "inputs_filled_ratio": np.array(
+                [self._inputs_filled_ratio(snapshot)], dtype=np.float32
+            ),
+            "cart_items": np.array([float(snapshot.cart_items)], dtype=np.float32),
+        }
+        return obs
+
+    def _encode_history(self, history: Deque[int]) -> np.ndarray:
+        arr = np.zeros((self.history_length,), dtype=np.int32)
+        for idx, action in enumerate(list(history)[-self.history_length :]):
+            arr[idx] = int(action)
+        return arr
+
+    def _encode_meta(self, rank: RankResult, top_k: int) -> np.ndarray:
+        arr = np.zeros((top_k, self.topk_meta_dim), dtype=np.float32)
+        for row, ranked in enumerate(rank.padded_elements(top_k)[:top_k]):
+            features = np.asarray(ranked.meta_features, dtype=np.float32)
+            limit = min(len(features), self.topk_meta_dim)
+            arr[row, :limit] = features[:limit]
+        return arr
+
+    def _encode_topk_text(self, rank: RankResult, top_k: int) -> np.ndarray:
+        arr = np.zeros((top_k, self.max_element_tokens), dtype=np.int32)
+        for row, ranked in enumerate(rank.padded_elements(top_k)[:top_k]):
+            arr[row] = self._encode_text(ranked.element.text, self.max_element_tokens, self.dom_vocab)
+        return arr
+
+    def _inputs_filled_ratio(self, snapshot: BrowserSnapshot) -> float:
+        values = snapshot.inputs_state.values
+        if not values:
+            return 0.0
+        filled = sum(1 for value in values.values() if value)
+        return min(1.0, filled / max(len(values), 1))
+
+
+__all__ = ["ObservationBuilder"]

--- a/rl/envs/rewards.py
+++ b/rl/envs/rewards.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+from .types import BrowserSnapshot, RewardSignal, TaskSpec
+from ..validator.iwa_evaluator_client import IWAValidator, ValidatorFeedback
+
+
+@dataclass
+class RewardConfig:
+    success_reward: float = 1.0
+    milestone_reward: float = 0.1
+    step_penalty: float = 0.001
+    invalid_action_penalty: float = 0.05
+    loop_penalty: float = 0.05
+
+    @classmethod
+    def from_mapping(cls, mapping: Optional[Mapping[str, float]]) -> "RewardConfig":
+        if mapping is None:
+            return cls()
+        params = {}
+        for field in cls.__dataclass_fields__.values():
+            value = mapping.get(field.name, getattr(cls, field.name))
+            if value is None:
+                value = getattr(cls, field.name)
+            params[field.name] = float(value)
+        return cls(**params)
+
+
+class RewardComputer:
+    def __init__(self, config: Optional[Mapping[str, float]] = None, validator: Optional[IWAValidator] = None):
+        self.cfg = RewardConfig.from_mapping(config)
+        self.validator = validator
+
+    def compute(
+        self,
+        task: TaskSpec,
+        previous: Optional[BrowserSnapshot],
+        current: BrowserSnapshot,
+        *,
+        invalid_action: bool = False,
+        loop_penalty: bool = False,
+    ) -> RewardSignal:
+        reward = -self.cfg.step_penalty
+        milestones: list[str] = []
+
+        if previous is not None:
+            if previous.url != current.url and current.url:
+                reward += self.cfg.milestone_reward
+                milestones.append("url_changed")
+
+            inputs_delta = current.inputs_state.diff(previous.inputs_state)
+            for key, (_, after) in inputs_delta.items():
+                if after:
+                    reward += self.cfg.milestone_reward
+                    milestones.append(f"input_filled:{key}")
+
+            if current.cart_items > previous.cart_items:
+                reward += self.cfg.milestone_reward
+                milestones.append("cart_increase")
+
+        feedback = ValidatorFeedback()
+        if self.validator is not None:
+            feedback = self.validator.evaluate(task=task, previous=previous, current=current)
+            if feedback.shaped_reward:
+                reward += float(feedback.shaped_reward)
+                if feedback.milestones:
+                    milestones.extend(feedback.milestones)
+
+        success = bool(feedback.success)
+        invalid_episode = bool(feedback.invalid)
+
+        if success:
+            reward += self.cfg.success_reward
+            milestones.append("success")
+
+        if invalid_action:
+            reward -= self.cfg.invalid_action_penalty
+
+        if loop_penalty:
+            reward -= self.cfg.loop_penalty
+            milestones.append("loop_penalty")
+
+        return RewardSignal(
+            reward=reward,
+            success=success,
+            invalid_episode=invalid_episode,
+            milestones=milestones,
+            invalid_action=invalid_action,
+        )
+
+
+__all__ = ["RewardComputer", "RewardConfig"]

--- a/rl/envs/types.py
+++ b/rl/envs/types.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+@dataclass
+class ElementMetadata:
+    """Normalized subset of DOM metadata used by the RL environment.
+
+    The browser driver is responsible for extracting these fields from the
+    underlying Playwright page or any other executor implementation.  We keep
+    the structure lightweight on purpose so it can be serialized, logged or
+    used inside vectorized environments without Playwright handles leaking.
+    """
+
+    element_id: str
+    role: Optional[str]
+    tag: Optional[str]
+    text: str
+    aria_label: Optional[str] = None
+    placeholder: Optional[str] = None
+    input_type: Optional[str] = None
+    clickable: bool = False
+    focusable: bool = False
+    editable: bool = False
+    is_visible: bool = True
+    is_enabled: bool = True
+    is_in_viewport: bool = True
+    bounding_box: Optional[Tuple[float, float, float, float]] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def label_candidates(self) -> Iterable[str]:
+        """Return text features that can be matched against the goal."""
+
+        if self.text:
+            yield self.text
+        if self.aria_label:
+            yield self.aria_label
+        if self.placeholder:
+            yield self.placeholder
+        for key in ("title", "name", "value"):
+            value = self.extra.get(key)
+            if isinstance(value, str) and value:
+                yield value
+
+
+@dataclass
+class RankedElement:
+    element: ElementMetadata
+    score: float
+    meta_features: Tuple[float, ...]
+
+
+@dataclass
+class RankResult:
+    elements: List[RankedElement]
+    click_mask: List[bool]
+    focus_mask: List[bool]
+
+    def padded_elements(self, k: int) -> List[RankedElement]:
+        """Return the ranked elements padded to length *k* with dummy entries."""
+
+        padding_needed = max(0, k - len(self.elements))
+        if padding_needed == 0:
+            return self.elements
+
+        meta_len = len(self.elements[0].meta_features) if self.elements else 0
+        dummy = RankedElement(
+            element=ElementMetadata(
+                element_id="__pad__",
+                role=None,
+                tag=None,
+                text="",
+                clickable=False,
+                focusable=False,
+                editable=False,
+                is_visible=False,
+                is_enabled=False,
+                is_in_viewport=False,
+            ),
+            score=0.0,
+            meta_features=tuple(0.0 for _ in range(meta_len)),
+        )
+        return self.elements + [dummy] * padding_needed
+
+
+@dataclass
+class TaskSpec:
+    task_id: str
+    demo_web_id: str
+    goal: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class BrowserInputsState:
+    values: Dict[str, str] = field(default_factory=dict)
+
+    def diff(self, other: "BrowserInputsState") -> Dict[str, Tuple[str, str]]:
+        """Return the set of keys that changed between two snapshots."""
+
+        delta: Dict[str, Tuple[str, str]] = {}
+        keys = set(self.values.keys()) | set(other.values.keys())
+        for key in keys:
+            current_val = self.values.get(key)
+            previous_val = other.values.get(key)
+            if current_val != previous_val:
+                delta[key] = (previous_val or "", current_val or "")
+        return delta
+
+
+@dataclass
+class BrowserSnapshot:
+    url: str
+    dom_text: str
+    elements: List[ElementMetadata]
+    inputs_state: BrowserInputsState = field(default_factory=BrowserInputsState)
+    cart_items: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def element_by_id(self, element_id: str) -> Optional[ElementMetadata]:
+        for element in self.elements:
+            if element.element_id == element_id:
+                return element
+        return None
+
+
+@dataclass
+class RewardSignal:
+    reward: float
+    success: bool
+    invalid_episode: bool
+    milestones: List[str] = field(default_factory=list)
+    invalid_action: bool = False
+
+
+@dataclass
+class ActionResult:
+    invalid: bool
+    description: str = ""
+    signature: str = ""
+
+
+__all__ = [
+    "ActionResult",
+    "BrowserInputsState",
+    "BrowserSnapshot",
+    "ElementMetadata",
+    "RankResult",
+    "RankedElement",
+    "RewardSignal",
+    "TaskSpec",
+]

--- a/rl/utils/__init__.py
+++ b/rl/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers for the IWA RL environment."""
+
+from .imports import load_object
+
+__all__ = ["load_object"]
+

--- a/rl/utils/imports.py
+++ b/rl/utils/imports.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Utility helpers for dynamic imports used by the RL environment."""
+
+import importlib
+from typing import Any
+
+
+def load_object(path: str) -> Any:
+    """Load an object from a fully-qualified import path.
+
+    Parameters
+    ----------
+    path:
+        String in the form ``"package.module:object"`` or ``"package.module.object"``.
+
+    Returns
+    -------
+    Any
+        The imported attribute.
+
+    Raises
+    ------
+    ImportError
+        If the module cannot be imported.
+    AttributeError
+        If the attribute does not exist within the module.
+    """
+
+    if not isinstance(path, str) or not path:
+        raise ValueError("Import path must be a non-empty string")
+
+    module_path: str
+    attr_name: str
+
+    if ":" in path:
+        module_path, attr_name = path.split(":", 1)
+    else:
+        parts = path.split(".")
+        if len(parts) < 2:
+            raise ValueError(
+                "Import path must include both module and attribute, e.g. 'pkg.mod:Class'"
+            )
+        module_path = ".".join(parts[:-1])
+        attr_name = parts[-1]
+
+    module = importlib.import_module(module_path)
+    try:
+        return getattr(module, attr_name)
+    except AttributeError as exc:  # pragma: no cover - precise error message
+        raise AttributeError(f"Module '{module_path}' has no attribute '{attr_name}'") from exc
+
+
+__all__ = ["load_object"]
+

--- a/rl/validator/__init__.py
+++ b/rl/validator/__init__.py
@@ -1,0 +1,6 @@
+"""Validator adapters for the IWA RL environment."""
+
+from .concurrent_adapter import ConcurrentEvaluatorAdapter
+from .iwa_evaluator_client import IWAValidator, ValidatorFeedback
+
+__all__ = ["ConcurrentEvaluatorAdapter", "IWAValidator", "ValidatorFeedback"]

--- a/rl/validator/concurrent_adapter.py
+++ b/rl/validator/concurrent_adapter.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+"""Adapters that bridge the RL validator with the IWA concurrent evaluator."""
+
+import logging
+import random
+from typing import Any, Mapping, Optional, Sequence
+
+from ..envs.types import BrowserSnapshot, TaskSpec
+
+logger = logging.getLogger(__name__)
+
+
+class ConcurrentEvaluatorAdapter:
+    """Thin wrapper around the IWA concurrent evaluator and task repositories."""
+
+    def __init__(
+        self,
+        *,
+        evaluator: Optional[Any] = None,
+        task_repository: Optional[Any] = None,
+        bootstrap_kwargs: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self._bootstrap_kwargs = dict(bootstrap_kwargs or {})
+        self._bootstrap = None
+        if evaluator is None or task_repository is None:
+            self._bootstrap = self._bootstrap_factory()
+        self._evaluator = evaluator or self._resolve_evaluator()
+        self._task_repository = task_repository or self._resolve_task_repository()
+
+        if self._evaluator is None:
+            raise RuntimeError(
+                "ConcurrentEvaluatorAdapter could not locate an evaluator. "
+                "Ensure autoppia_iwa is installed and AppBootstrap exposes one."
+            )
+        if self._task_repository is None:
+            raise RuntimeError(
+                "ConcurrentEvaluatorAdapter could not locate a task repository. "
+                "Provide one explicitly or ensure AppBootstrap exposes it."
+            )
+
+    # ------------------------------------------------------------------
+    # Task sampling
+    # ------------------------------------------------------------------
+    def sample_task(self, options: Optional[Mapping[str, Any]] = None) -> Mapping[str, Any]:
+        options = dict(options or {})
+        index = options.get("index")
+
+        repository = self._task_repository
+        task = None
+
+        if index is not None:
+            for method_name in (
+                "get_by_index",
+                "get_task_by_index",
+                "task_at",
+                "__getitem__",
+            ):
+                method = getattr(repository, method_name, None)
+                if callable(method):
+                    try:
+                        task = method(index)
+                        break
+                    except Exception:  # pragma: no cover - defensive path
+                        continue
+
+        if task is None:
+            for method_name in ("sample_task", "sample", "random", "get_random_task"):
+                method = getattr(repository, method_name, None)
+                if callable(method):
+                    try:
+                        task = method(options)
+                        break
+                    except TypeError:
+                        try:
+                            task = method()
+                            break
+                        except Exception:  # pragma: no cover - defensive path
+                            continue
+
+        if task is None and hasattr(repository, "tasks"):
+            tasks = getattr(repository, "tasks")
+            try:
+                tasks_list = list(tasks)
+            except TypeError:  # pragma: no cover - defensive path
+                tasks_list = []
+            if tasks_list:
+                index = int(index) % len(tasks_list) if index is not None else random.randrange(len(tasks_list))
+                task = tasks_list[index]
+
+        if task is None:
+            raise RuntimeError("Task repository did not return a task")
+
+        return self._task_to_dict(task)
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+    def evaluate_snapshot(
+        self,
+        *,
+        task: TaskSpec,
+        previous: Optional[BrowserSnapshot],
+        current: BrowserSnapshot,
+    ) -> Any:
+        evaluator = self._evaluator
+        candidates: Sequence[str] = (
+            "evaluate_snapshot",
+            "evaluate_state",
+            "evaluate",
+            "__call__",
+        )
+        task_obj = self._to_task_object(task)
+        for name in candidates:
+            method = getattr(evaluator, name, None)
+            if callable(method):
+                try:
+                    if name == "__call__":
+                        return method(task_obj, previous, current)
+                    return method(task=task_obj, previous=previous, current=current)
+                except TypeError:
+                    try:
+                        return method(task_obj, previous, current)
+                    except Exception as exc:  # pragma: no cover - best effort
+                        logger.debug("Evaluator %s failed via %s: %s", evaluator, name, exc)
+                        continue
+                except Exception as exc:  # pragma: no cover - best effort
+                    logger.debug("Evaluator %s failed via %s: %s", evaluator, name, exc)
+                    continue
+        raise AttributeError(
+            f"Evaluator {type(evaluator)!r} does not expose a callable evaluation method"
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _bootstrap_factory(self):
+        try:
+            from autoppia_iwa.src.bootstrap import AppBootstrap  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.warning("Failed to import AppBootstrap: %s", exc)
+            return None
+        return AppBootstrap(**self._bootstrap_kwargs)
+
+    def _resolve_evaluator(self) -> Optional[Any]:
+        bootstrap = self._bootstrap
+        if bootstrap is None:
+            return None
+        for attr in ("concurrent_evaluator", "evaluator", "benchmark_evaluator"):
+            evaluator = getattr(bootstrap, attr, None)
+            if evaluator is not None:
+                return evaluator
+        container = getattr(bootstrap, "di_container", None)
+        if container is not None:
+            for key in (
+                "concurrent_evaluator",
+                "benchmark_evaluator",
+                "validator_evaluator",
+            ):
+                try:
+                    evaluator = container.resolve(key)  # type: ignore[attr-defined]
+                    if evaluator is not None:
+                        return evaluator
+                except Exception:  # pragma: no cover - optional dependency
+                    continue
+        return None
+
+    def _resolve_task_repository(self) -> Optional[Any]:
+        bootstrap = self._bootstrap
+        if bootstrap is None:
+            return None
+        for attr in (
+            "task_repository",
+            "benchmark_task_repository",
+            "tasks_repository",
+            "benchmark_dataset",
+        ):
+            repository = getattr(bootstrap, attr, None)
+            if repository is not None:
+                return repository
+        container = getattr(bootstrap, "di_container", None)
+        if container is not None:
+            for key in (
+                "task_repository",
+                "benchmark_task_repository",
+                "tasks_repository",
+            ):
+                try:
+                    repository = container.resolve(key)  # type: ignore[attr-defined]
+                    if repository is not None:
+                        return repository
+                except Exception:  # pragma: no cover - optional dependency
+                    continue
+        return None
+
+    @staticmethod
+    def _task_to_dict(task: Any) -> Mapping[str, Any]:
+        task_id = getattr(task, "id", None) or getattr(task, "task_id", None) or ""
+        demo_web_id = getattr(task, "demo_web_id", None) or getattr(task, "project_id", None) or ""
+        goal = getattr(task, "prompt", None) or getattr(task, "goal", None) or ""
+        metadata = getattr(task, "metadata", None) or getattr(task, "extra", None) or {}
+        return {
+            "task_id": str(task_id),
+            "demo_web_id": str(demo_web_id),
+            "goal": str(goal),
+            "metadata": dict(metadata) if isinstance(metadata, Mapping) else {},
+        }
+
+    def _to_task_object(self, task: TaskSpec) -> Any:
+        try:
+            from autoppia_iwa.src.data_generation.domain.classes import Task as IWATask  # type: ignore
+        except Exception:  # pragma: no cover - optional dependency
+            return task
+
+        try:
+            return IWATask(
+                id=task.task_id,
+                prompt=task.goal,
+                demo_web_id=task.demo_web_id,
+                metadata=task.metadata,
+            )
+        except TypeError:
+            try:
+                return IWATask(
+                    task_id=task.task_id,
+                    goal=task.goal,
+                    demo_web_id=task.demo_web_id,
+                    metadata=task.metadata,
+                )
+            except Exception:  # pragma: no cover - fallback to TaskSpec
+                return task
+
+
+__all__ = ["ConcurrentEvaluatorAdapter"]
+

--- a/rl/validator/iwa_evaluator_client.py
+++ b/rl/validator/iwa_evaluator_client.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Mapping, Optional
+
+from ..envs.types import BrowserSnapshot, TaskSpec
+from ..utils import load_object
+
+
+@dataclass
+class ValidatorFeedback:
+    success: bool = False
+    invalid: bool = False
+    shaped_reward: float = 0.0
+    milestones: List[str] = None
+
+    def __post_init__(self) -> None:
+        if self.milestones is None:
+            self.milestones = []
+
+
+class IWAValidator:
+    """Thin adapter on top of the IWA evaluator client."""
+
+    def __init__(
+        self,
+        config: Optional[Mapping[str, Any]] = None,
+        client: Optional[Any] = None,
+    ) -> None:
+        self._config = dict(config or {})
+        if client is None:
+            client_cfg = dict(self._config.get("client") or {})
+            client = self._load_client_from_config(client_cfg)
+        self._client = client
+
+    # ------------------------------------------------------------------
+    # Task sampling helpers
+    # ------------------------------------------------------------------
+    def sample_task(self, options: Optional[Mapping[str, Any]] = None) -> TaskSpec:
+        options = options or {}
+        if hasattr(self._client, "sample_task"):
+            task_dict = self._client.sample_task(options)
+        else:
+            task_pool: Iterable[Mapping[str, Any]] = self._config.get("task_pool") or []
+            if not task_pool:
+                raise RuntimeError("Task pool is empty; configure validator.task_pool or provide a client")
+            task_dict = dict(task_pool[int(options.get("index", 0)) % len(task_pool)])
+        return TaskSpec(
+            task_id=str(task_dict.get("task_id")),
+            demo_web_id=str(task_dict.get("demo_web_id")),
+            goal=str(task_dict.get("goal")),
+            metadata=dict(task_dict.get("metadata") or {}),
+        )
+
+    # ------------------------------------------------------------------
+    # Evaluation helpers
+    # ------------------------------------------------------------------
+    def evaluate(
+        self,
+        task: TaskSpec,
+        previous: Optional[BrowserSnapshot],
+        current: BrowserSnapshot,
+    ) -> ValidatorFeedback:
+        if self._client is None:
+            return ValidatorFeedback()
+
+        if hasattr(self._client, "evaluate_snapshot"):
+            result = self._client.evaluate_snapshot(task=task, previous=previous, current=current)
+        elif hasattr(self._client, "evaluate"):
+            result = self._client.evaluate(task=task, snapshot=current)
+        else:
+            raise AttributeError("Validator client must expose evaluate_snapshot or evaluate")
+
+        if isinstance(result, ValidatorFeedback):
+            return result
+
+        # Attempt to coerce dictionaries or other simple structures
+        success = bool(result.get("success")) if isinstance(result, Mapping) else False
+        invalid = bool(result.get("invalid")) if isinstance(result, Mapping) else False
+        shaped_reward = float(result.get("reward", 0.0)) if isinstance(result, Mapping) else 0.0
+        milestones = list(result.get("milestones", [])) if isinstance(result, Mapping) else []
+        return ValidatorFeedback(
+            success=success,
+            invalid=invalid,
+            shaped_reward=shaped_reward,
+            milestones=milestones,
+        )
+
+    def _load_client_from_config(self, client_cfg: Mapping[str, object]) -> Optional[Any]:
+        if not client_cfg:
+            return None
+
+        entrypoint = client_cfg.get("class") or client_cfg.get("entrypoint")
+        if not entrypoint:
+            raise ValueError("Validator client configuration must include 'class' or 'entrypoint'")
+
+        try:
+            client_cls = load_object(str(entrypoint))
+        except (ImportError, AttributeError) as exc:
+            # Defer to task_pool based sampling if the heavy dependency is missing.
+            from logging import getLogger
+
+            getLogger(__name__).warning(
+                "Failed to import validator client '%s': %s", entrypoint, exc
+            )
+            return None
+
+        kwargs = dict(client_cfg.get("kwargs") or {})
+        return client_cls(**kwargs)
+
+
+__all__ = ["IWAValidator", "ValidatorFeedback"]

--- a/tests/rl/test_env_components.py
+++ b/tests/rl/test_env_components.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from collections import deque
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _ensure_gym_stub() -> None:
+    import importlib
+    import types
+
+    if "gymnasium" in sys.modules:
+        return
+
+    try:
+        importlib.import_module("gymnasium")
+        return
+    except ModuleNotFoundError:
+        pass
+
+    class Env:
+        metadata: dict[str, object] = {}
+
+        def __init__(self, *_, **__):
+            self.metadata = {}
+
+        def reset(self, *, seed=None, options=None):  # pragma: no cover - stub
+            return None
+
+        def step(self, action):  # pragma: no cover - stub
+            raise NotImplementedError
+
+    class Discrete:
+        def __init__(self, n: int):
+            self.n = int(n)
+
+    class Box:
+        def __init__(self, low, high, shape, dtype):
+            self.low = low
+            self.high = high
+            self.shape = shape
+            self.dtype = dtype
+
+    class Dict:
+        def __init__(self, spaces_dict):
+            self.spaces = dict(spaces_dict)
+
+        def items(self):
+            return self.spaces.items()
+
+        def __getitem__(self, key):
+            return self.spaces[key]
+
+    spaces_module = types.ModuleType("gymnasium.spaces")
+    spaces_module.Discrete = Discrete
+    spaces_module.Box = Box
+    spaces_module.Dict = Dict
+
+    gym_module = types.ModuleType("gymnasium")
+    gym_module.Env = Env
+    gym_module.spaces = spaces_module
+
+    sys.modules["gymnasium"] = gym_module
+    sys.modules["gymnasium.spaces"] = spaces_module
+
+
+_ensure_gym_stub()
+
+from rl.drivers.browser import Browser
+from rl.envs.dom_ranker import rank_clickables
+from rl.envs.obs_builders import ObservationBuilder
+from rl.envs.rewards import RewardComputer
+from rl.envs.types import (
+    BrowserInputsState,
+    BrowserSnapshot,
+    ElementMetadata,
+    RankResult,
+    TaskSpec,
+)
+from rl.validator.iwa_evaluator_client import ValidatorFeedback
+
+
+class StubBrowserAdapter:
+    def __init__(self) -> None:
+        self._snapshot = BrowserSnapshot(
+            url="https://demo",
+            dom_text="Go to checkout",
+            elements=[
+                ElementMetadata(
+                    element_id="link",
+                    role="link",
+                    tag="a",
+                    text="Checkout",
+                    clickable=True,
+                    focusable=False,
+                    is_in_viewport=True,
+                )
+            ],
+        )
+
+    def reset(self, demo_web_id: str) -> BrowserSnapshot:
+        return self._snapshot
+
+    def snapshot(self) -> BrowserSnapshot:
+        return self._snapshot
+
+    def click(self, element_id: str) -> BrowserSnapshot:
+        self._snapshot.metadata["clicked"] = element_id
+        return self._snapshot
+
+    def focus(self, element_id: str) -> BrowserSnapshot:
+        self._snapshot.metadata["focused"] = element_id
+        return self._snapshot
+
+    def type_and_confirm(self, text: str) -> BrowserSnapshot:
+        self._snapshot.inputs_state.values["field"] = text
+        return self._snapshot
+
+    def submit(self) -> BrowserSnapshot:
+        self._snapshot.metadata["submitted"] = True
+        return self._snapshot
+
+    def scroll(self, direction: str) -> BrowserSnapshot:
+        self._snapshot.metadata["scrolled"] = direction
+        return self._snapshot
+
+    def back(self) -> BrowserSnapshot:
+        self._snapshot.metadata["back"] = True
+        return self._snapshot
+
+
+@pytest.fixture
+def sample_task() -> TaskSpec:
+    return TaskSpec(task_id="t1", demo_web_id="demo", goal="Submit the checkout form")
+
+
+@pytest.fixture
+def sample_elements() -> list[ElementMetadata]:
+    return [
+        ElementMetadata(
+            element_id="button",
+            role="button",
+            tag="button",
+            text="Submit order",
+            clickable=True,
+            focusable=False,
+            is_in_viewport=True,
+        ),
+        ElementMetadata(
+            element_id="input",
+            role="textbox",
+            tag="input",
+            text="Email",
+            clickable=True,
+            focusable=True,
+            editable=True,
+            is_in_viewport=True,
+        ),
+        ElementMetadata(
+            element_id="hidden",
+            role="button",
+            tag="button",
+            text="Hidden",
+            clickable=True,
+            focusable=False,
+            is_visible=False,
+        ),
+    ]
+
+
+def test_rank_clickables_orders_visible_elements(sample_task: TaskSpec, sample_elements: list[ElementMetadata]):
+    rank = rank_clickables(sample_elements, sample_task, top_k=3)
+    element_ids = [item.element.element_id for item in rank.elements]
+    assert element_ids == ["input", "button"]
+    assert rank.click_mask == [True, True]
+    assert rank.focus_mask == [True, False]
+
+
+def test_observation_builder_shapes(sample_task: TaskSpec, sample_elements: list[ElementMetadata]):
+    builder = ObservationBuilder({})
+    rank = RankResult(
+        elements=rank_clickables(sample_elements, sample_task, top_k=2).elements,
+        click_mask=[True, True],
+        focus_mask=[False, True],
+    )
+    snapshot = BrowserSnapshot(
+        url="https://demo/step",
+        dom_text="Submit order now",
+        elements=sample_elements,
+        inputs_state=BrowserInputsState(values={"input": "user@example.com"}),
+        cart_items=2,
+    )
+    history = deque([1, 2, 3], maxlen=builder.history_length)
+    obs = builder.build(sample_task, snapshot, rank, history, top_k=3)
+
+    assert obs["goal_ids"].shape == (builder.max_goal_tokens,)
+    assert obs["dom_ids"].shape == (builder.max_dom_tokens,)
+    assert obs["topk_meta"].shape == (3, builder.topk_meta_dim)
+    assert obs["topk_text_ids"].shape == (3, builder.max_element_tokens)
+    assert obs["prev_actions"].shape == (builder.history_length,)
+    assert obs["inputs_filled_ratio"].item() > 0.0
+    assert obs["cart_items"].item() == pytest.approx(2.0)
+
+
+def test_reward_computer_combines_milestones(sample_task: TaskSpec):
+    previous = BrowserSnapshot(
+        url="https://demo/start",
+        dom_text="Start",
+        elements=[],
+        inputs_state=BrowserInputsState(values={"input": ""}),
+        cart_items=0,
+    )
+    current = BrowserSnapshot(
+        url="https://demo/finish",
+        dom_text="Finish",
+        elements=[],
+        inputs_state=BrowserInputsState(values={"input": "value"}),
+        cart_items=1,
+    )
+
+    class DummyValidator:
+        def evaluate(self, task: TaskSpec, previous, current):
+            return ValidatorFeedback(success=True, shaped_reward=0.5, milestones=["validator"])
+
+    computer = RewardComputer(
+        config={
+            "success_reward": 1.0,
+            "milestone_reward": 0.1,
+            "step_penalty": 0.01,
+        },
+        validator=DummyValidator(),
+    )
+
+    signal = computer.compute(sample_task, previous, current)
+    assert pytest.approx(signal.reward, rel=1e-6) == 1.79
+    assert signal.success
+    assert "url_changed" in signal.milestones
+    assert "input_filled:input" in signal.milestones
+    assert "cart_increase" in signal.milestones
+    assert "validator" in signal.milestones
+
+
+def test_browser_instantiates_adapter_from_config():
+    browser = Browser(
+        config={
+            "adapter": {
+                "class": "tests.rl.test_env_components:StubBrowserAdapter",
+            }
+        }
+    )
+
+    snapshot = browser.reset_to_demo("demo")
+    assert snapshot.url == "https://demo"
+
+    element = browser.get_visible_elements()[0]
+    browser.click(element)
+    assert browser.snapshot.metadata["clicked"] == "link"

--- a/tests/rl/test_env_mock.py
+++ b/tests/rl/test_env_mock.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _ensure_gym_stub() -> None:
+    import importlib
+    import types
+
+    if "gymnasium" in sys.modules:
+        return
+
+    try:
+        importlib.import_module("gymnasium")
+        return
+    except ModuleNotFoundError:
+        pass
+
+    class Env:  # minimal stub
+        metadata: dict[str, object] = {}
+
+        def __init__(self, *_, **__):
+            self.metadata = {}
+
+        def reset(self, *, seed=None, options=None):  # pragma: no cover - stub
+            return None
+
+        def step(self, action):  # pragma: no cover - stub
+            raise NotImplementedError
+
+    class Discrete:
+        def __init__(self, n: int):
+            self.n = int(n)
+
+    class Box:
+        def __init__(self, low, high, shape, dtype):
+            self.low = low
+            self.high = high
+            self.shape = shape
+            self.dtype = dtype
+
+    class Dict:
+        def __init__(self, spaces_dict):
+            self.spaces = dict(spaces_dict)
+
+        def items(self):
+            return self.spaces.items()
+
+        def __getitem__(self, key):
+            return self.spaces[key]
+
+    spaces_module = types.ModuleType("gymnasium.spaces")
+    spaces_module.Discrete = Discrete
+    spaces_module.Box = Box
+    spaces_module.Dict = Dict
+
+    gym_module = types.ModuleType("gymnasium")
+    gym_module.Env = Env
+    gym_module.spaces = spaces_module
+
+    sys.modules["gymnasium"] = gym_module
+    sys.modules["gymnasium.spaces"] = spaces_module
+
+
+_ensure_gym_stub()
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints only
+    from rl.drivers.browser import BrowserAdapter
+    from rl.envs.types import BrowserInputsState, BrowserSnapshot, ElementMetadata, TaskSpec
+    from rl.validator.iwa_evaluator_client import IWAValidator, ValidatorFeedback
+
+
+def test_env_reset_and_step():
+    from rl.drivers.browser import Browser, BrowserAdapter
+    from rl.envs import IWAWebEnv, MacroAction
+    from rl.envs.types import BrowserInputsState, BrowserSnapshot, ElementMetadata, TaskSpec
+    from rl.validator.iwa_evaluator_client import IWAValidator, ValidatorFeedback
+
+    class MockBrowserAdapter(BrowserAdapter):
+        def __init__(self) -> None:
+            self.reset("demo")
+
+        def reset(self, demo_web_id: str) -> BrowserSnapshot:  # noqa: D401 - part of protocol
+            self._typed = False
+            self._submitted = False
+            self._elements = [
+                ElementMetadata(
+                    element_id="btn",
+                    role="button",
+                    tag="button",
+                    text="Submit",
+                    clickable=True,
+                    focusable=False,
+                ),
+                ElementMetadata(
+                    element_id="input",
+                    role="textbox",
+                    tag="input",
+                    text="",
+                    clickable=True,
+                    focusable=True,
+                    editable=True,
+                ),
+            ]
+            self._snapshot = BrowserSnapshot(
+                url="https://example.com",
+                dom_text="Submit form",
+                elements=list(self._elements),
+                inputs_state=BrowserInputsState(values={}),
+                metadata={},
+            )
+            return self._snapshot
+
+        def snapshot(self) -> BrowserSnapshot:
+            return self._snapshot
+
+        def click(self, element_id: str) -> BrowserSnapshot:
+            snapshot = self._clone_snapshot()
+            snapshot.metadata["clicked"] = element_id
+            self._snapshot = snapshot
+            return snapshot
+
+        def focus(self, element_id: str) -> BrowserSnapshot:
+            snapshot = self._clone_snapshot()
+            snapshot.metadata["focused"] = element_id
+            self._snapshot = snapshot
+            return snapshot
+
+        def type_and_confirm(self, text: str) -> BrowserSnapshot:
+            self._typed = True
+            snapshot = self._clone_snapshot()
+            snapshot.inputs_state.values["input"] = text
+            snapshot.metadata["typed"] = True
+            self._snapshot = snapshot
+            return snapshot
+
+        def submit(self) -> BrowserSnapshot:
+            self._submitted = True
+            snapshot = self._clone_snapshot()
+            snapshot.metadata["submitted"] = True
+            self._snapshot = snapshot
+            return snapshot
+
+        def scroll(self, direction: str) -> BrowserSnapshot:
+            snapshot = self._clone_snapshot()
+            snapshot.metadata["scrolled"] = direction
+            self._snapshot = snapshot
+            return snapshot
+
+        def back(self) -> BrowserSnapshot:
+            snapshot = self._clone_snapshot()
+            snapshot.metadata["went_back"] = True
+            self._snapshot = snapshot
+            return snapshot
+
+        def _clone_snapshot(self) -> BrowserSnapshot:
+            return BrowserSnapshot(
+                url=self._snapshot.url,
+                dom_text=self._snapshot.dom_text,
+                elements=list(self._elements),
+                inputs_state=BrowserInputsState(values=dict(self._snapshot.inputs_state.values)),
+                cart_items=self._snapshot.cart_items,
+                metadata=dict(self._snapshot.metadata),
+            )
+
+    class MockValidatorClient:
+        def sample_task(self, options):
+            return {
+                "task_id": "1",
+                "demo_web_id": "demo",
+                "goal": "Submit the form",
+            }
+
+        def evaluate_snapshot(self, task: TaskSpec, previous, current):
+            success = bool(current.metadata.get("submitted"))
+            shaped_reward = 0.1 if current.metadata.get("typed") else 0.0
+            milestones = ["typed"] if shaped_reward else []
+            if success:
+                milestones.append("submitted")
+            return ValidatorFeedback(success=success, shaped_reward=shaped_reward, milestones=milestones)
+
+    browser = Browser(adapter=MockBrowserAdapter())
+    validator = IWAValidator(client=MockValidatorClient())
+    env = IWAWebEnv(cfg={"topk": 2}, browser=browser, validator=validator)
+
+    obs, info = env.reset()
+    assert "action_mask" in info
+    assert obs["topk_meta"].shape == (env.K, env.observation_builder.topk_meta_dim)
+
+    mask = info["action_mask"]
+    click_action = env.action_offset_click
+    assert mask[click_action]
+
+    obs, reward, terminated, truncated, info = env.step(int(click_action))
+    assert isinstance(obs, dict)
+    assert isinstance(reward, float)
+    assert isinstance(terminated, bool)
+    assert isinstance(truncated, bool)
+    assert "action_mask" in info
+
+    invalid_focus_action = env.action_offset_focus
+    obs, reward, terminated, truncated, info = env.step(int(invalid_focus_action))
+    assert info["invalid_action"]
+    assert reward < 0.0
+    assert not terminated
+
+    valid_focus_action = env.action_offset_focus + 1
+    assert info["action_mask"][valid_focus_action]
+    obs, reward, terminated, truncated, info = env.step(int(valid_focus_action))
+    assert not info["invalid_action"]
+
+    type_action = env.action_offset_macros + MacroAction.TYPE_CONFIRM
+    assert info["action_mask"][type_action]
+    obs, reward, terminated, truncated, info = env.step(int(type_action))
+    assert "typed" in info["milestones"] or reward > 0.0
+
+    submit_action = env.action_offset_macros + MacroAction.SUBMIT
+    assert info["action_mask"][submit_action]
+    obs, reward, terminated, truncated, info = env.step(int(submit_action))
+    assert terminated
+    assert info["success"]

--- a/tests/rl/test_mock_policy_pipeline.py
+++ b/tests/rl/test_mock_policy_pipeline.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import numpy as np
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _ensure_gym_stub() -> None:
+    import importlib
+    import types
+
+    if "gymnasium" in sys.modules:
+        return
+
+    try:
+        importlib.import_module("gymnasium")
+        return
+    except ModuleNotFoundError:
+        pass
+
+    class Env:  # pragma: no cover - compatibility stub
+        metadata: dict[str, object] = {}
+
+        def __init__(self, *_, **__):
+            self.metadata = {}
+
+        def reset(self, *, seed=None, options=None):  # pragma: no cover - stub
+            return None
+
+        def step(self, action):  # pragma: no cover - stub
+            raise NotImplementedError
+
+    class Discrete:
+        def __init__(self, n: int):
+            self.n = int(n)
+
+    class Dict:
+        def __init__(self, spaces_dict):
+            self.spaces = dict(spaces_dict)
+
+    spaces_module = types.ModuleType("gymnasium.spaces")
+    spaces_module.Discrete = Discrete
+    spaces_module.Dict = Dict
+
+    gym_module = types.ModuleType("gymnasium")
+    gym_module.Env = Env
+    gym_module.spaces = spaces_module
+
+    sys.modules["gymnasium"] = gym_module
+    sys.modules["gymnasium.spaces"] = spaces_module
+
+
+_ensure_gym_stub()
+
+
+def test_mock_ppo_rollout_zero_reward():
+    from rl.drivers.browser import Browser, BrowserAdapter
+    from rl.envs import IWAWebEnv
+    from rl.envs.types import BrowserInputsState, BrowserSnapshot, ElementMetadata, TaskSpec
+    from rl.validator.iwa_evaluator_client import IWAValidator, ValidatorFeedback
+
+    class StaticBrowserAdapter(BrowserAdapter):
+        def __init__(self) -> None:
+            self._snapshot = BrowserSnapshot(
+                url="https://example.com",
+                dom_text="Sample page",
+                elements=[
+                    ElementMetadata(
+                        element_id="noop",
+                        role="paragraph",
+                        tag="p",
+                        text="Nothing to do",
+                        clickable=False,
+                        focusable=False,
+                    )
+                ],
+                inputs_state=BrowserInputsState(values={}),
+                metadata={"can_go_back": False},
+            )
+
+        def reset(self, demo_web_id: str) -> BrowserSnapshot:
+            return self._snapshot
+
+        def snapshot(self) -> BrowserSnapshot:
+            return self._snapshot
+
+        def click(self, element_id: str) -> BrowserSnapshot:
+            return self._snapshot
+
+        def focus(self, element_id: str) -> BrowserSnapshot:
+            return self._snapshot
+
+        def type_and_confirm(self, text: str) -> BrowserSnapshot:
+            return self._snapshot
+
+        def submit(self) -> BrowserSnapshot:
+            return self._snapshot
+
+        def scroll(self, direction: str) -> BrowserSnapshot:
+            return self._snapshot
+
+        def back(self) -> BrowserSnapshot:
+            return self._snapshot
+
+    class ZeroValidatorClient:
+        def __init__(self) -> None:
+            self.evaluate_calls = 0
+
+        def sample_task(self, options):
+            return {
+                "task_id": "static",
+                "demo_web_id": "static_web",
+                "goal": "Stay idle",
+            }
+
+        def evaluate_snapshot(self, task: TaskSpec, previous, current):
+            self.evaluate_calls += 1
+            return ValidatorFeedback(success=False, shaped_reward=0.0, milestones=[])
+
+    browser = Browser(adapter=StaticBrowserAdapter())
+    validator_client = ZeroValidatorClient()
+    validator = IWAValidator(client=validator_client)
+    env = IWAWebEnv(cfg={"max_steps": 5, "topk": 1}, browser=browser, validator=validator)
+
+    class MockPPO:
+        def __init__(self, action_space):
+            self.action_space = action_space
+
+        def predict(self, observation, state=None, mask=None, deterministic=True):
+            # Always choose NOOP to emulate a non-trained policy.
+            return np.array([0]), state
+
+    policy = MockPPO(env.action_space)
+    task_override = {
+        "task_id": "static",
+        "demo_web_id": "static_web",
+        "goal": "Stay idle",
+    }
+
+    observation, info = env.reset(options={"task": task_override})
+    total_reward = 0.0
+    done = False
+    steps = 0
+    state = None
+
+    while not done:
+        action, state = policy.predict(observation, state=state, mask=info.get("action_mask"))
+        observation, reward, terminated, truncated, info = env.step(int(action.item()))
+        steps += 1
+        total_reward += reward
+        done = terminated or truncated
+        if steps > env.max_steps + 1:  # pragma: no cover - safety guard
+            break
+
+    assert steps >= 1
+    assert validator_client.evaluate_calls >= steps
+    assert info.get("success") is False
+    assert total_reward <= 0.0


### PR DESCRIPTION
## Summary
- allow the RL environment to accept explicit task specifications during reset so tests can target concrete demo webs
- add a mock PPO rollout test that exercises the browser and validator adapters end-to-end and expects zero success

## Testing
- pytest tests/rl -q
- python -m compileall rl

------
https://chatgpt.com/codex/tasks/task_e_68fd0464371c8330bb4b626ea754a73d