### PR TITLE
Improve validator round summaries and tooling

### DIFF
--- a/autoppia_web_agents_subnet/validator/visualization/round_table.py
+++ b/autoppia_web_agents_subnet/validator/visualization/round_table.py
@@ -20,6 +20,100 @@ def _mean_safe(values: list[float]) -> float:
     return float(np.mean(np.asarray(values, dtype=np.float32)))
 
 
+MAX_TERMINAL_WIDTH = 118
+BASE_COLUMN_WIDTH = 3 + 5 + 12 + 6 + 10 + 11 + 6  # estimated from explicit widths below
+VALIDATOR_COLUMN_WIDTH = 12
+
+
+def _derive_round_number(round_manager) -> Optional[int]:
+    """Best-effort calculation of the human-readable round number."""
+
+    try:
+        block_length = int(getattr(round_manager, "ROUND_BLOCK_LENGTH", 0))
+        if block_length <= 0:
+            return None
+
+        start_block = getattr(round_manager, "start_block", None)
+        if start_block is None:
+            try:
+                boundaries = round_manager.get_current_boundaries()
+                start_block = int(boundaries.get("round_start_block"))
+            except Exception:  # noqa: BLE001
+                start_block = None
+        if start_block is None:
+            return None
+
+        base_block = getattr(round_manager, "minimum_start_block", None) or 0
+        blocks_since_start = max(int(start_block) - int(base_block), 0)
+        round_index = blocks_since_start // block_length
+        return int(round_index + 1)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _chunk_indices(length: int, chunk_size: int) -> List[range]:
+    if length <= 0:
+        return [range(0)]
+    ranges: List[range] = []
+    for start in range(0, length, chunk_size):
+        stop = min(start + chunk_size, length)
+        ranges.append(range(start, stop))
+    return ranges
+
+
+def _coerce_score_mapping(raw: Optional[Any]) -> Dict[int, float]:
+    """Normalize various score payload shapes into {uid: score}."""
+
+    mapping: Dict[int, float] = {}
+    if raw is None:
+        return mapping
+
+    try:
+        if isinstance(raw, dict):
+            candidate = raw
+            # Some payloads wrap the scores under a named key (e.g. "avg_reward").
+            if any(isinstance(k, str) and not k.isdigit() for k in candidate.keys()):
+                for key in ("avg_reward", "scores", "final_score", "data"):
+                    nested = candidate.get(key)
+                    if isinstance(nested, dict):
+                        candidate = nested
+                        break
+            for key, value in candidate.items():
+                try:
+                    uid = int(key)
+                    mapping[uid] = float(value)
+                except Exception:  # noqa: BLE001
+                    continue
+            return mapping
+
+        if isinstance(raw, list):
+            for entry in raw:
+                if not isinstance(entry, dict):
+                    continue
+                uid = entry.get("uid") or entry.get("miner_uid")
+                score_value = (
+                    entry.get("avg_reward")
+                    if entry.get("avg_reward") is not None
+                    else entry.get("score")
+                )
+                if score_value is None:
+                    score_value = entry.get("final_score")
+                if uid is None or score_value is None:
+                    continue
+                try:
+                    mapping[int(uid)] = float(score_value)
+                except Exception:  # noqa: BLE001
+                    continue
+            return mapping
+
+        if hasattr(raw, "to_dict"):
+            return _coerce_score_mapping(raw.to_dict())
+    except Exception:  # noqa: BLE001
+        return mapping
+
+    return mapping
+
+
 def render_round_summary_table(
     round_manager,
     final_rewards: Dict[int, float],  # WTA rewards mapping (1.0 to winner)
@@ -36,10 +130,13 @@ def render_round_summary_table(
     Sorted by Reward desc.
     """
     rows: list[dict[str, Any]] = []
+    round_number = _derive_round_number(round_manager)
 
     # Decide which UIDs to show: if agg_scores provided, show only UIDs with final score > 0
-    if agg_scores:
-        uids_to_show = {int(uid) for uid, sc in agg_scores.items() if float(sc) > 0.0}
+    normalized_scores = _coerce_score_mapping(agg_scores)
+
+    if normalized_scores:
+        uids_to_show = {int(uid) for uid, sc in normalized_scores.items() if float(sc) > 0.0}
     else:
         uids_to_show = set(list(round_manager.round_rewards.keys()) + list(final_rewards.keys()))
 
@@ -57,7 +154,7 @@ def render_round_summary_table(
         avg_eval = _mean_safe(round_manager.round_eval_scores.get(uid, []))
         avg_time = _mean_safe(round_manager.round_times.get(uid, []))
         local_participated = bool(round_manager.round_rewards.get(uid)) or bool(round_manager.round_eval_scores.get(uid))
-        final_score = float((agg_scores or {}).get(uid, 0.0))
+        final_score = float(normalized_scores.get(uid, 0.0))
         wta_reward = float(final_rewards.get(uid, 0.0))  # 1.0 for winner else 0.0
 
         # Per-validator scores for this UID, ordered by validators_hk_order
@@ -87,19 +184,22 @@ def render_round_summary_table(
             Console().print(text)
         return text
 
+    title_base = "Round Summary — Miners"
+    if round_number is not None:
+        title_base = f"{title_base} — Round {round_number}"
+
     if _RICH:
-        tbl = Table(
-            title="[bold magenta]Round Summary — Miners[/bold magenta]",
-            box=box.SIMPLE_HEAVY,
-            header_style="bold cyan",
-            expand=True,
-            show_lines=False,
-            padding=(0, 1),
-        )
+        max_validator_cols = 0
+        if validators_hk_order:
+            available = max(MAX_TERMINAL_WIDTH - BASE_COLUMN_WIDTH, VALIDATOR_COLUMN_WIDTH)
+            max_validator_cols = max(1, available // VALIDATOR_COLUMN_WIDTH)
+        validator_ranges = _chunk_indices(len(validators_hk_order), max_validator_cols or 1)
+
         # Header note with validators and stakes (weights used)
         if validators_info:
             try:
                 from rich.console import Console as _C
+
                 hdr = ", ".join(
                     [
                         f"{v.get('hotkey', '')[:10]}…({float(v.get('stake') or 0.0):.0f}τ)"
@@ -107,68 +207,128 @@ def render_round_summary_table(
                     ]
                 )
                 _C().print(f"[bold]Aggregators:[/bold] {hdr}")
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
-        tbl.add_column("#", justify="right", width=3)
-        tbl.add_column("UID", justify="right", width=5)
-        tbl.add_column("Hotkey", style="cyan", overflow="ellipsis")
-        tbl.add_column("Active", justify="center", width=6)
-        tbl.add_column("LocalScore", justify="right", width=10)
-        # Per-validator dynamic columns
-        if validators_hk_order:
-            for idx, v in enumerate(validators_info, start=1):
-                hk = v.get("hotkey", "")
-                stake = float(v.get("stake") or 0.0)
-                header = f"V{idx}:{hk[:6]}…({stake:.0f}τ)"
-                tbl.add_column(header, justify="right", width=12)
-        tbl.add_column("FinalScore", justify="right", width=11)
-        tbl.add_column("WTA", justify="right", width=6)
-
-        for i, r in enumerate(rows, start=1):
-            base_cols = [
-                str(i),
-                str(r["uid"]),
-                r["hotkey_prefix"],
-                ("yes" if (active_uids and r["uid"] in active_uids) else ("yes" if r["local"] else "no")),
-                f'{r["avg_eval"]:.4f}',
-            ]
-            pv_cols = []
-            if validators_hk_order and r.get("per_val_scores"):
-                pv_cols = [f"{val:.4f}" for val in r["per_val_scores"]]
-            tail_cols = [
-                f'{r["final_score"]:.4f}',
-                f'{r["wta_reward"]:.4f}',
-            ]
-            tbl.add_row(*(base_cols + pv_cols + tail_cols))
-
         console = Console()
-        console.print(tbl)
-        return f"Round Summary — Miners (n={len(rows)})."
+
+        for part_idx, rng in enumerate(validator_ranges, start=1):
+            title = title_base
+            if len(validator_ranges) > 1:
+                title = f"{title} (part {part_idx})"
+
+            tbl = Table(
+                title=f"[bold magenta]{title}[/bold magenta]",
+                box=box.SIMPLE_HEAVY,
+                header_style="bold cyan",
+                expand=False,
+                show_lines=False,
+                padding=(0, 1),
+            )
+
+            tbl.add_column("#", justify="right", width=3)
+            tbl.add_column("UID", justify="right", width=5)
+            tbl.add_column("Hotkey", style="cyan", width=12, overflow="ellipsis")
+            tbl.add_column("Active", justify="center", width=6)
+            tbl.add_column("LocalScore", justify="right", width=10)
+
+            if validators_hk_order:
+                for idx in rng:
+                    validator = validators_info[idx]
+                    hk = validator.get("hotkey", "")
+                    stake = float(validator.get("stake") or 0.0)
+                    header = f"V{idx + 1}:{hk[:6]}…({stake:.0f}τ)"
+                    tbl.add_column(header, justify="right", width=12)
+
+            tbl.add_column("FinalScore", justify="right", width=11)
+            tbl.add_column("WTA", justify="right", width=6)
+
+            for i, r in enumerate(rows, start=1):
+                base_cols = [
+                    str(i),
+                    str(r["uid"]),
+                    r["hotkey_prefix"],
+                    ("yes" if (active_uids and r["uid"] in active_uids) else ("yes" if r["local"] else "no")),
+                    f'{r["avg_eval"]:.4f}',
+                ]
+                pv_cols: List[str] = []
+                if validators_hk_order and r.get("per_val_scores"):
+                    pv_cols = [
+                        f"{r['per_val_scores'][idx]:.4f}" if idx < len(r["per_val_scores"]) else "0.0000"
+                        for idx in rng
+                    ]
+                tail_cols = [
+                    f'{r["final_score"]:.4f}',
+                    f'{r["wta_reward"]:.4f}',
+                ]
+                tbl.add_row(*(base_cols + pv_cols + tail_cols))
+
+            console.print(tbl)
+
+        return f"{title_base} (n={len(rows)}, sections={len(validator_ranges)})."
 
     # Fallback plain text table
-    # Plain text fallback
-    header = [
-        "#", "UID", "HOTKEY", "Active", "LocalScore",
+    header_base = ["#", "UID", "Hotkey", "Active", "LocalScore"]
+    tail_headers = ["FinalScore", "WTA"]
+    validator_headers = [
+        f"V{idx}:{v.get('hotkey', '')[:6]}…({float(v.get('stake') or 0.0):.0f}τ)"
+        for idx, v in enumerate(validators_info, start=1)
     ]
-    if validators_info:
-        header.extend([f"V{idx}:{v.get('hotkey','')[:6]}…({float(v.get('stake') or 0.0):.0f}τ)" for idx, v in enumerate(validators_info, start=1)])
-    header.extend(["FinalScore", "WTA"])
 
-    lines = [
-        "Round Summary — Miners",
-        " ".join([f"{h:>12}" for h in header]),
-    ]
-    for i, r in enumerate(rows, start=1):
-        fields = [
-            f"{i:>3}", f"{r['uid']:>5}", f"{r['hotkey_prefix']:<12.12}",
-            ("yes" if (active_uids and r["uid"] in active_uids) else ("yes" if r["local"] else "no")),
-            f"{r['avg_eval']:.4f}",
+    available = max(MAX_TERMINAL_WIDTH - BASE_COLUMN_WIDTH, VALIDATOR_COLUMN_WIDTH)
+    max_validator_cols = max(1, available // VALIDATOR_COLUMN_WIDTH) if validator_headers else 1
+    validator_ranges = _chunk_indices(len(validator_headers), max_validator_cols)
+
+    lines: List[str] = []
+    for part_idx, rng in enumerate(validator_ranges, start=1):
+        title = title_base
+        if len(validator_ranges) > 1:
+            title = f"{title} (part {part_idx})"
+        lines.append(title)
+
+        headers = header_base + [validator_headers[i] for i in rng] + tail_headers
+        header_formats = [
+            "{:>3}",
+            "{:>5}",
+            "{:<12}",
+            "{:>6}",
+            "{:>10}",
         ]
-        if validators_hk_order and r.get("per_val_scores"):
-            fields.extend([f"{val:.4f}" for val in r["per_val_scores"]])
-        fields.extend([f"{r['final_score']:.4f}", f"{r['wta_reward']:.4f}"])
-        lines.append(" ".join([f"{x:>12}" for x in fields]))
+        header_formats.extend(["{:>12}"] * len(rng))
+        header_formats.extend(["{:>11}", "{:>6}"])
+        lines.append(" ".join(fmt.format(h) for fmt, h in zip(header_formats, headers)))
+
+        for i, r in enumerate(rows, start=1):
+            row_base = [
+                i,
+                r["uid"],
+                r["hotkey_prefix"][:12],
+                ("yes" if (active_uids and r["uid"] in active_uids) else ("yes" if r["local"] else "no")),
+                f"{r['avg_eval']:.4f}",
+            ]
+            validator_values = []
+            if validators_hk_order and r.get("per_val_scores"):
+                validator_values = [
+                    f"{r['per_val_scores'][idx]:.4f}" if idx < len(r["per_val_scores"]) else "0.0000"
+                    for idx in rng
+                ]
+            tail_values = [f"{r['final_score']:.4f}", f"{r['wta_reward']:.4f}"]
+
+            values = row_base + validator_values + tail_values
+            row_formats = [
+                "{:>3}",
+                "{:>5}",
+                "{:<12}",
+                "{:>6}",
+                "{:>10}",
+            ]
+            row_formats.extend(["{:>12}"] * len(validator_values))
+            row_formats.extend(["{:>11}", "{:>6}"])
+            lines.append(" ".join(fmt.format(val) for fmt, val in zip(row_formats, values)))
+
+        if part_idx < len(validator_ranges):
+            lines.append("")
+
     text = "\n".join(lines)
     if to_console:
         print(text)

--- a/scripts/validator/summary.sh
+++ b/scripts/validator/summary.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEFAULT_LINES=${LINES:-4000}
+DEFAULT_PM2_IDENTIFIER=${PM2_IDENTIFIER:-}
+
+usage() {
+    cat <<'USAGE'
+Usage: summary.sh [--round N] [--pm2 NAME|ID] [--path LOGFILE] [--lines N]
+
+Summarize validator round information from pm2 logs.
+
+Options:
+  --round N   Round number to summarize. When omitted, the latest completed round is used.
+  --pm2 ID    pm2 process id or name to pull logs from (default: $PM2_IDENTIFIER or required when --path omitted).
+  --path FILE Path to a log file instead of pm2 logs.
+  --lines N   Number of log lines to read (default: 4000 or $LINES env).
+  -h, --help  Show this help message.
+
+Either --pm2 or --path must be provided. When both are supplied, --path takes precedence.
+USAGE
+}
+
+round_arg=""
+pm2_identifier="$DEFAULT_PM2_IDENTIFIER"
+log_path=""
+lines="$DEFAULT_LINES"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --round)
+            [[ $# -lt 2 ]] && { echo "Missing value for --round" >&2; exit 1; }
+            round_arg="$2"
+            shift 2
+            ;;
+        --pm2)
+            [[ $# -lt 2 ]] && { echo "Missing value for --pm2" >&2; exit 1; }
+            pm2_identifier="$2"
+            shift 2
+            ;;
+        --path)
+            [[ $# -lt 2 ]] && { echo "Missing value for --path" >&2; exit 1; }
+            log_path="$2"
+            shift 2
+            ;;
+        --lines)
+            [[ $# -lt 2 ]] && { echo "Missing value for --lines" >&2; exit 1; }
+            lines="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$log_path" && -z "$pm2_identifier" ]]; then
+    echo "Error: provide either --pm2 or --path" >&2
+    usage >&2
+    exit 1
+fi
+
+if ! [[ "$lines" =~ ^[0-9]+$ ]]; then
+    echo "Error: --lines must be an integer" >&2
+    exit 1
+fi
+
+collect_logs() {
+    if [[ -n "$log_path" ]]; then
+        if [[ ! -f "$log_path" ]]; then
+            echo "Error: log file not found: $log_path" >&2
+            exit 1
+        fi
+        tail -n "$lines" "$log_path"
+    else
+        if ! command -v pm2 >/dev/null 2>&1; then
+            echo "Error: pm2 command not found. Install pm2 or provide --path" >&2
+            exit 1
+        fi
+        pm2 logs "$pm2_identifier" --lines "$lines" --nostream
+    fi
+}
+
+mapfile -t LOG_LINES < <(collect_logs | sed -e 's/\x1B\[[0-9;]*[A-Za-z]//g')
+
+if [[ ${#LOG_LINES[@]} -eq 0 ]]; then
+    echo "No log lines collected." >&2
+    exit 1
+fi
+
+log_text=$(printf '%s\n' "${LOG_LINES[@]}")
+
+extract_latest_round() {
+    local latest_round=""
+    while IFS= read -r line; do
+        if [[ "$line" =~ Round[[:space:]]+completed:\ ([0-9]+) ]]; then
+            latest_round="${BASH_REMATCH[1]}"
+        fi
+    done <<< "$log_text"
+    echo "$latest_round"
+}
+
+target_round="$round_arg"
+if [[ -z "$target_round" ]]; then
+    target_round=$(extract_latest_round)
+    if [[ -z "$target_round" ]]; then
+        echo "Unable to locate a completed round in logs." >&2
+        exit 1
+    fi
+fi
+
+if ! [[ "$target_round" =~ ^[0-9]+$ ]]; then
+    echo "Invalid round number: $target_round" >&2
+    exit 1
+fi
+
+start_index=-1
+end_index=-1
+
+for idx in "${!LOG_LINES[@]}"; do
+    line=${LOG_LINES[$idx]}
+    if [[ "$line" =~ Round[[:space:]]+completed:\ ([0-9]+) ]]; then
+        if [[ "${BASH_REMATCH[1]}" == "$target_round" ]]; then
+            end_index=$idx
+        fi
+    fi
+done
+
+if (( end_index < 0 )); then
+    echo "Could not find completion marker for round $target_round" >&2
+    exit 1
+fi
+
+for (( idx=end_index; idx>=0; idx-- )); do
+    line=${LOG_LINES[$idx]}
+    if [[ "$line" =~ Starting[[:space:]]+Round:\ ([0-9]+) ]]; then
+        if [[ "${BASH_REMATCH[1]}" == "$target_round" ]]; then
+            start_index=$idx
+            break
+        fi
+    elif [[ "$line" =~ Starting[[:space:]]+round-based[[:space:]]+forward[[:space:]]*\(round[[:space:]]*([0-9]+)\) ]]; then
+        if [[ "${BASH_REMATCH[1]}" == "$target_round" ]]; then
+            start_index=$idx
+            break
+        fi
+    fi
+
+done
+
+if (( start_index < 0 )); then
+    echo "Could not find start marker for round $target_round" >&2
+    exit 1
+fi
+
+round_lines=("${LOG_LINES[@]:$start_index:$((end_index - start_index + 1))}")
+round_text=$(printf '%s\n' "${round_lines[@]}")
+
+print_section() {
+    local title="$1"
+    local content="$2"
+    if [[ -n "${content// }" ]]; then
+        printf '\n=== %s ===\n' "$title"
+        printf '%s\n' "$content"
+    fi
+}
+
+first_marker=$(printf '%s\n' "${round_lines[0]}")
+last_index=$(( ${#round_lines[@]} - 1 ))
+completion_marker=$(printf '%s\n' "${round_lines[$last_index]}")
+
+task_ready=$(printf '%s\n' "${round_lines[@]}" | grep -F "Task list ready" | head -n1 || true)
+tasks_completed=$(printf '%s\n' "${round_lines[@]}" | grep -F "Tasks completed" | tail -n1 || true)
+round_id=$(printf '%s\n' "${round_lines[@]}" | grep -F "validator_round_id" | head -n1 || true)
+wta_winner=$(printf '%s\n' "${round_lines[@]}" | grep -F "🏆 Winner" | tail -n1 || true)
+consensus_lines=$(printf '%s\n' "${round_lines[@]}" | grep -Ei "commit|consensus|aggregated" || true)
+score_lines=$(printf '%s\n' "${round_lines[@]}" | grep -E "(Scattered rewards|Updated moving avg scores|Final weights|Updating scores)" || true)
+
+tables=$(printf '%s\n' "${round_lines[@]}" | awk '
+    /Round Summary — Miners/ {
+        if (in_block) {
+            print "";
+        }
+        in_block=1;
+    }
+    in_block {
+        print $0;
+        if ($0 ~ /^\s*$/) {
+            in_block=0;
+        }
+    }
+')
+
+commitments=$(printf '%s\n' "${round_lines[@]}" | grep -Ei "commitment" || true)
+aggregators=$(printf '%s\n' "${round_lines[@]}" | grep -F "Aggregators:" | tail -n1 || true)
+
+printf 'Validator round summary (round %s)\n' "$target_round"
+if [[ -n "$log_path" ]]; then
+    source_desc="$log_path"
+else
+    source_desc="pm2:$pm2_identifier (last $lines lines)"
+fi
+printf 'Source: %s\n' "$source_desc"
+
+round_markers=$(printf '%s\n%s' "$first_marker" "$completion_marker")
+task_summary=$(printf '%s\n%s' "$task_ready" "$tasks_completed")
+consensus_summary=$(printf '%s\n%s\n' "$consensus_lines" "$commitments" | awk 'NF { if (!seen[$0]++) print }')
+
+print_section "Round markers" "$round_markers"
+print_section "Identifiers" "$round_id"
+print_section "Tasks" "$task_summary"
+print_section "Consensus & commitments" "$consensus_summary"
+print_section "Score updates" "$score_lines"
+print_section "Winner" "$wta_winner"
+print_section "Aggregators" "$aggregators"
+print_section "Round Summary tables" "$tables"
+
+if [[ -z "${tables// }" ]]; then
+    print_section "Raw log excerpt" "$round_text"
+fi


### PR DESCRIPTION
## Summary
- render the round summary table in width-aware sections, include the round number, and normalise upstream score payloads
- log explicit start/completion markers for each round so pm2 output can be sliced accurately
- add a validator summary script that extracts a round from pm2 or file logs, falling back to legacy start markers when locating the slice
- surface aggregator metadata in the summary report alongside round tables

## Testing
- python -m compileall neurons/validator.py autoppia_web_agents_subnet/validator/visualization/round_table.py
- bash -n scripts/validator/summary.sh

------
https://chatgpt.com/codex/tasks/task_e_68ff73075b008330836ed7273877e186