### PR TITLE
fix: specify ValueError in except clause for float conversion

### DIFF
--- a/autoppia_web_agents_subnet/validator/reporting/codex_analyzer.py
+++ b/autoppia_web_agents_subnet/validator/reporting/codex_analyzer.py
@@ -171,7 +171,7 @@ def _generate_intelligent_analysis(report: RoundReport, context: dict) -> Option
                     failing_webs.append(web_name)
                 elif rate < 30:
                     low_success_webs.append(f"{web_name} ({rate_str})")
-            except:
+            except ValueError:
                 pass
 
         if failing_webs:


### PR DESCRIPTION
The float() call can specifically raise ValueError when parsing invalid strings. Catching the specific exception makes the error handling more explicit and follows Python best practices.