### PR TITLE
ci: add GitHub Actions workflow for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files --show-diff-on-failure
+
+  test-unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TESTING: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: pytest -m unit --tb=short -q
+
+  test-property:
+    name: Property Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TESTING: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run property tests
+        run: pytest -m property --tb=short -q


### PR DESCRIPTION
## Summary
Add CI pipeline (`.github/workflows/ci.yml`) with three parallel jobs that run on every push to `main` and all PRs:
- **Lint & Format** — enforces pre-commit hooks (ruff check + ruff format, line-length 200)
- **Unit Tests** — `pytest -m unit` with `TESTING=true`
- **Property Tests** — `pytest -m property` with `TESTING=true`

## Why
Pre-commit hooks exist but are not enforced — code that fails linting or breaks tests can be pushed without any gate. This adds the missing enforcement layer.

## Changes
- New file: `.github/workflows/ci.yml` (77 lines)
- No changes to existing code
- Jobs include: pip/pre-commit caching, job timeouts (5min lint, 10min tests), concurrency grouping to cancel stale runs, `--show-diff-on-failure` for lint

## Test plan
- [ ] Verify lint job catches formatting violations
- [ ] Verify unit tests run with `TESTING=true` environment
- [ ] Verify property tests run in parallel with unit tests
- [ ] Confirm stale PR runs are cancelled when new commits are pushed