### PR TITLE
Refactor `autoppia-miner-cli` into layered modules

### DIFF
--- a/autoppia_web_agents_subnet/miner/cli.py
+++ b/autoppia_web_agents_subnet/miner/cli.py
@@ -23,283 +23,134 @@ By default ``submit`` targets the NEXT round of the CURRENT season.
 """
 from __future__ import annotations
 
-import argparse
 import asyncio
-import sys
+from collections.abc import Awaitable, Callable
+from typing import Any
 
-import bittensor as bt
-from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
-from rich.text import Text
+import click
 
-from autoppia_web_agents_subnet.opensource.utils_git import normalize_and_validate_github_url
-from autoppia_web_agents_subnet.utils.commitments import write_plain_commitment_json, read_my_plain_json
+from autoppia_web_agents_subnet import SUBNET_IWA_VERSION
 
-console = Console()
-err_console = Console(stderr=True)
+from .help import StyledAliasGroup
+from .service import DEFAULT_NETUID, CommonOptions, MinerCliError, run_show, run_submit
+from .ui import print_banner, print_error
 
-# CLI defaults mirroring validator config to keep it self-contained without env vars.
-_BLOCKS_PER_EPOCH = 360
-_DEFAULT_SEASON_SIZE_EPOCHS = 280.0
-_DEFAULT_ROUND_SIZE_EPOCHS = 4.0
-_DEFAULT_MINIMUM_START_BLOCK = 7_586_110
-_DEFAULT_NETUID = 36
 
-# Season / round helpers
-def _season_block_length() -> int:
-    return int(_BLOCKS_PER_EPOCH * _DEFAULT_SEASON_SIZE_EPOCHS)
+def _common_options(func: Callable[..., Any]) -> Callable[..., Any]:
+    options = [
+        click.option("--wallet.name", "wallet_name", default="default", show_default=True, help="Wallet coldkey name."),
+        click.option("--wallet.hotkey", "wallet_hotkey", default="default", show_default=True, help="Wallet hotkey name."),
+        click.option(
+            "--subtensor.network",
+            "subtensor_network",
+            default="finney",
+            show_default=True,
+            help="Subtensor network.",
+        ),
+        click.option(
+            "--subtensor.chain_endpoint",
+            "subtensor_chain_endpoint",
+            default=None,
+            help="Subtensor chain endpoint URL.",
+        ),
+        click.option("--netuid", type=int, default=DEFAULT_NETUID, show_default=True, help="Subnet netuid."),
+    ]
+    for option in reversed(options):
+        func = option(func)
+    return func
 
-def _round_block_length() -> int:
-    return int(_BLOCKS_PER_EPOCH * _DEFAULT_ROUND_SIZE_EPOCHS)
 
-def compute_season(current_block: int) -> int:
-    base = _DEFAULT_MINIMUM_START_BLOCK
-    if current_block < base:
-        return 0
-    return int((current_block - base) // _season_block_length()) + 1
+def _run_async(coro: Awaitable[None]) -> None:
+    try:
+        asyncio.run(coro)
+    except MinerCliError as exc:
+        print_error(str(exc))
+        raise click.exceptions.Exit(1)
+    except Exception as exc:
+        print_error(f"{type(exc).__name__}: {exc}")
+        raise click.exceptions.Exit(1)
 
-def compute_season_start_block(season_number: int) -> int:
-    if season_number <= 0:
-        return _DEFAULT_MINIMUM_START_BLOCK
-    return _DEFAULT_MINIMUM_START_BLOCK + (season_number - 1) * _season_block_length()
 
-def compute_current_round(current_block: int, season_number: int) -> int:
-    season_start = compute_season_start_block(season_number)
-    effective = max(current_block, season_start)
-    return int((effective - season_start) // _round_block_length()) + 1
+@click.group(cls=StyledAliasGroup, invoke_without_command=True)
+@click.version_option(version=SUBNET_IWA_VERSION, prog_name="autoppia-miner-cli")
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """
+    Submit miner agent metadata as an on-chain commitment.
+    
+    """
+    if ctx.invoked_subcommand is None:
+        print_banner()
+        click.echo(ctx.get_help())
+        raise click.exceptions.Exit(1)
 
-def compute_next_round(current_block: int, season_number: int) -> int:
-    return compute_current_round(current_block, season_number) + 1
 
-# Display helpers
-def _banner() -> None:
-    console.print(
-        Panel(
-            Text("autoppia-miner-cli", style="bold cyan", justify="center"),
-            subtitle="Miner Agent On-Chain Commitment Tool",
-            border_style="bright_blue",
+@cli.command("submit")
+@click.option(
+    "--github",
+    required=True,
+    help="GitHub repo URL with ref, e.g. https://github.com/owner/repo/tree/branch",
+)
+@click.option("--agent.name", "agent_name", required=True, help="Agent display name.")
+@click.option("--agent.image", "agent_image", default="", help="Agent Docker image (optional).")
+@click.option("--target_round", type=int, default=None, help="Round to target (default: next round of this season).")
+@click.option("--season", type=int, default=None, help="Season number (default: current season).")
+@_common_options
+def submit_command(
+    github: str,
+    agent_name: str,
+    agent_image: str,
+    target_round: int | None,
+    season: int | None,
+    wallet_name: str,
+    wallet_hotkey: str,
+    subtensor_network: str,
+    subtensor_chain_endpoint: str | None,
+    netuid: int,
+) -> None:
+    """Write a miner commitment on-chain."""
+    options = CommonOptions(
+        wallet_name=wallet_name,
+        wallet_hotkey=wallet_hotkey,
+        subtensor_network=subtensor_network,
+        subtensor_chain_endpoint=subtensor_chain_endpoint,
+        netuid=netuid,
+    )
+    _run_async(
+        run_submit(
+            options=options,
+            github=github,
+            agent_name=agent_name,
+            agent_image=agent_image,
+            target_round=target_round,
+            season=season,
         )
     )
-    console.print()
 
-def _wallet_table(wallet: bt.Wallet, network: str, netuid: int) -> Table:
-    table = Table(show_header=False, border_style="dim", pad_edge=False, box=None)
-    table.add_column("Key", style="bold")
-    table.add_column("Value")
-    table.add_row("Wallet", f"{wallet.name} / {wallet.hotkey_str}")
-    table.add_row("Hotkey", f"{wallet.hotkey.ss58_address}")
-    table.add_row("Network", network)
-    table.add_row("Netuid", str(netuid))
-    return table
 
-def _chain_info_table(current_block: int, season: int, current_round: int, target_round: int | None = None) -> Table:
-    table = Table(show_header=False, border_style="dim", pad_edge=False, box=None)
-    table.add_column("Key", style="bold")
-    table.add_column("Value")
-    table.add_row("Current block", f"{current_block:,}")
-    table.add_row("Season", str(season))
-    table.add_row("Current round", str(current_round))
-    if target_round is not None:
-        table.add_row("Target round", f"[bold yellow]{target_round}[/bold yellow]")
-    return table
-
-def _error(msg: str) -> None:
-    err_console.print(f"[bold red]ERROR:[/bold red] {msg}")
-
-def _warn(msg: str) -> None:
-    console.print(f"[bold yellow]WARNING:[/bold yellow] {msg}")
-
-def _success(msg: str) -> None:
-    console.print(f"[bold green]OK:[/bold green] {msg}")
-
-# Argument parser
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="autoppia-miner-cli",
-        description="Submit miner agent metadata as an on-chain commitment.",
+@cli.command("show")
+@_common_options
+def show_command(
+    wallet_name: str,
+    wallet_hotkey: str,
+    subtensor_network: str,
+    subtensor_chain_endpoint: str | None,
+    netuid: int,
+) -> None:
+    """Read the current on-chain commitment for this wallet."""
+    options = CommonOptions(
+        wallet_name=wallet_name,
+        wallet_hotkey=wallet_hotkey,
+        subtensor_network=subtensor_network,
+        subtensor_chain_endpoint=subtensor_chain_endpoint,
+        netuid=netuid,
     )
-    sub = parser.add_subparsers(dest="command")
-
-    # -- submit ----------------------------------------------------------------
-    submit_p = sub.add_parser("submit", help="Write a miner commitment on-chain.")
-    submit_p.add_argument("--github", required=True, help="GitHub repo URL with ref, e.g. https://github.com/owner/repo/tree/branch")
-    submit_p.add_argument("--agent.name", dest="agent_name", required=True, help="Agent display name.")
-    submit_p.add_argument("--agent.image", dest="agent_image", default="", help="Agent Docker image (optional).")
-    submit_p.add_argument("--target_round", type=int, default=None, help="Round to target (default: next round of this season).")
-    submit_p.add_argument("--season", type=int, default=None, help="Season number (default: current season).")
-    _add_common_args(submit_p)
-
-    # -- show ------------------------------------------------------------------
-    show_p = sub.add_parser("show", help="Read the current on-chain commitment for this wallet.")
-    _add_common_args(show_p)
-
-    return parser
-
-def _add_common_args(p: argparse.ArgumentParser) -> None:
-    p.add_argument("--wallet.name", dest="wallet_name", default="default", help="Wallet coldkey name.")
-    p.add_argument("--wallet.hotkey", dest="wallet_hotkey", default="default", help="Wallet hotkey name.")
-    p.add_argument("--subtensor.network", dest="subtensor_network", default="finney", help="Subtensor network.")
-    p.add_argument("--subtensor.chain_endpoint", dest="subtensor_chain_endpoint", default=None, help="Subtensor chain endpoint URL.")
-    p.add_argument("--netuid", type=int, default=_DEFAULT_NETUID, help="Subnet netuid.")
-
-# Core logic
-async def _submit(args: argparse.Namespace) -> None:
-    _banner()
-
-    # Validate GitHub URL
-    normalized, ref = normalize_and_validate_github_url(args.github, require_ref=True)
-    if normalized is None:
-        _error(
-            f"Invalid GitHub URL: {args.github}\n"
-            "       Must be https://github.com/owner/repo/tree/<ref> or /commit/<sha>."
-        )
-        sys.exit(1)
-
-    # Reconstruct the full URL with ref for the commitment
-    github_url = f"{normalized}/tree/{ref}" if ref else normalized
-
-    agent_name = args.agent_name.strip()
-    if not agent_name:
-        _error("--agent.name must not be empty.")
-        sys.exit(1)
-
-    agent_image = (args.agent_image or "").strip()
-
-    # Connect to subtensor
-    wallet = bt.Wallet(name=args.wallet_name, hotkey=args.wallet_hotkey)
-    subtensor_kwargs = {"network": args.subtensor_network}
-    if args.subtensor_chain_endpoint:
-        subtensor_kwargs["network"] = args.subtensor_chain_endpoint
-
-    console.print(Panel(_wallet_table(wallet, args.subtensor_network, args.netuid), title="Wallet", border_style="blue"))
-
-    async with bt.AsyncSubtensor(**subtensor_kwargs) as st:
-        with console.status("[bold cyan]Connecting to subtensor...", spinner="dots"):
-            current_block = await st.get_current_block()
-
-        # Resolve season
-        season = args.season if args.season is not None else compute_season(current_block)
-
-        # Resolve round
-        target_round = args.target_round
-        if target_round is None:
-            target_round = compute_next_round(current_block, season)
-
-        cur_round = compute_current_round(current_block, season)
-        console.print(Panel(
-            _chain_info_table(current_block, season, cur_round, target_round),
-            title="Chain State",
-            border_style="blue",
-        ))
-
-        # Build compact commitment payload
-        payload = {
-            "t": "m",
-            "g": github_url,
-            "n": agent_name,
-            "r": int(target_round),
-            "s": int(season),
-        }
-        if agent_image:
-            payload["i"] = agent_image
-
-        console.print(Panel(_commitment_detail_table(payload), title="Commitment Payload", border_style="blue"))
-
-        with console.status("[bold cyan]Submitting commitment on-chain...", spinner="dots"):
-            ok = await write_plain_commitment_json(
-                st,
-                wallet=wallet,
-                data=payload,
-                netuid=args.netuid,
-            )
-
-        if ok:
-            _success("Commitment submitted successfully.")
-        else:
-            _error("Commitment submission failed.")
-            sys.exit(1)
-
-        # Read back to confirm
-        with console.status("[bold cyan]Verifying on-chain commitment...", spinner="dots"):
-            readback = await read_my_plain_json(st, wallet=wallet, netuid=args.netuid)
-
-        if readback:
-            console.print(Panel(_commitment_detail_table(readback), title="On-Chain Verification", border_style="green"))
-        else:
-            _warn("Could not read back commitment (may take a block to propagate).")
+    _run_async(run_show(options=options))
 
 
-async def _show(args: argparse.Namespace) -> None:
-    _banner()
-
-    wallet = bt.Wallet(name=args.wallet_name, hotkey=args.wallet_hotkey)
-    subtensor_kwargs = {"network": args.subtensor_network}
-    if args.subtensor_chain_endpoint:
-        subtensor_kwargs["network"] = args.subtensor_chain_endpoint
-
-    console.print(Panel(_wallet_table(wallet, args.subtensor_network, args.netuid), title="Wallet", border_style="blue"))
-
-    async with bt.AsyncSubtensor(**subtensor_kwargs) as st:
-        with console.status("[bold cyan]Connecting to subtensor...", spinner="dots"):
-            current_block = await st.get_current_block()
-
-        season = compute_season(current_block)
-        cur_round = compute_current_round(current_block, season)
-
-        console.print(Panel(
-            _chain_info_table(current_block, season, cur_round),
-            title="Chain State",
-            border_style="blue",
-        ))
-
-        with console.status("[bold cyan]Reading commitment...", spinner="dots"):
-            commitment = await read_my_plain_json(st, wallet=wallet, netuid=args.netuid)
-
-        if commitment is None:
-            _warn("No commitment found on-chain for this hotkey.")
-        else:
-            console.print(Panel(_commitment_detail_table(commitment), title="On-Chain Commitment", border_style="green"))
-
-
-def _commitment_detail_table(data: dict) -> Table:
-    _FIELD_LABELS = {
-        "t": ("Type", lambda v: "miner" if v == "m" else "validator" if v == "v" else str(v)),
-        "g": ("GitHub", str),
-        "n": ("Agent name", str),
-        "r": ("Round", str),
-        "s": ("Season", str),
-        "i": ("Image", str),
-    }
-    table = Table(show_header=False, border_style="dim", pad_edge=False, box=None)
-    table.add_column("Field", style="bold")
-    table.add_column("Value")
-    for key, value in data.items():
-        if key in _FIELD_LABELS:
-            label, fmt = _FIELD_LABELS[key]
-            table.add_row(label, fmt(value))
-        else:
-            table.add_row(key, str(value))
-    return table
-
-# Entrypoint
 def main() -> None:
-    parser = build_parser()
-    args = parser.parse_args()
+    cli()
 
-    if not args.command:
-        _banner()
-        parser.print_help()
-        sys.exit(1)
-
-    if args.command == "submit":
-        asyncio.run(_submit(args))
-    elif args.command == "show":
-        asyncio.run(_show(args))
-    else:
-        _banner()
-        parser.print_help()
-        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/autoppia_web_agents_subnet/miner/help.py
+++ b/autoppia_web_agents_subnet/miner/help.py
@@ -1,0 +1,231 @@
+# The MIT License (MIT)
+# Copyright © 2025 Entrius
+
+"""Shared Click group classes with Rich-powered help output."""
+
+from __future__ import annotations
+
+from inspect import cleandoc
+
+import click
+from rich import box
+from rich.console import Console
+from rich.markup import escape
+from rich.padding import Padding
+from rich.panel import Panel
+from rich.table import Table
+
+
+def _single_paragraph(text: str) -> str:
+    """Collapse multiline help text into a single paragraph."""
+    return ' '.join(text.split())
+
+
+def _collect_help_rows(params: list[click.Parameter], ctx: click.Context) -> list[tuple[str, str]]:
+    """Collect Click help records for parameters."""
+    rows: list[tuple[str, str]] = []
+    for param in params:
+        record = param.get_help_record(ctx)
+        if record is None:
+            continue
+        rows.append((record[0], record[1] or ''))
+    return rows
+
+
+def _render_usage(console: Console, usage: str) -> None:
+    """Render the usage line with styling."""
+    usage = usage.strip()
+    if usage.startswith('Usage:'):
+        usage_template = usage[len('Usage:') :].strip()
+        console.print(
+            Padding(
+                f'[bold yellow]Usage:[/bold yellow] [bold white]{escape(usage_template)}[/bold white]',
+                (0, 0, 0, 1),
+            )
+        )
+        console.print()
+        return
+
+    console.print(Padding(f'[bold white]{escape(usage)}[/bold white]', (0, 0, 0, 1)))
+    console.print()
+
+
+def _section_panel(
+    title: str,
+    rows: list[tuple[str, str]],
+    left_style: str = 'bold cyan',
+    right_style: str = 'bright_white',
+) -> Panel:
+    table = Table.grid(expand=True)
+    table.add_column(style=left_style, no_wrap=True, ratio=1, justify='left')
+    table.add_column(style=right_style, ratio=4, justify='left')
+
+    if rows:
+        for left, right in rows:
+            table.add_row(left, right)
+    else:
+        table.add_row('-', 'No entries')
+
+    return Panel(
+        table,
+        title=f' {title} ',
+        title_align='left',
+        border_style='grey66',
+        box=box.ROUNDED,
+        padding=(0, 1),
+    )
+
+
+def _parse_option_decl(option_decl: str) -> tuple[str, str, str]:
+    """Split Click option declaration into long names, short alias, and type."""
+    names_part = option_decl.strip()
+    option_type = ''
+
+    if ' ' in names_part:
+        maybe_names, maybe_type = names_part.rsplit(' ', 1)
+        if maybe_type.isupper() or (maybe_type.startswith('[') and maybe_type.endswith(']')):
+            names_part = maybe_names
+            option_type = maybe_type
+
+    tokens = [token.strip() for token in names_part.split(',') if token.strip()]
+    short_tokens = [token for token in tokens if token.startswith('-') and not token.startswith('--')]
+    long_tokens = [token for token in tokens if token.startswith('--')]
+
+    long_names = ','.join(long_tokens) if long_tokens else ','.join(tokens)
+    short_alias = ','.join(short_tokens)
+    return long_names, short_alias, option_type
+
+
+def _options_panel(rows: list[tuple[str, str]]) -> Panel:
+    """Render btcli-style options panel with explicit type column."""
+    table = Table.grid(expand=True)
+    table.add_column(style='bold cyan', no_wrap=True, ratio=4, justify='left')
+    table.add_column(style='bold green', no_wrap=True, ratio=1, justify='left')
+    table.add_column(style='bold yellow', no_wrap=True, ratio=1, justify='left')
+    table.add_column(style='bright_white', ratio=7, justify='left')
+
+    if rows:
+        for decl, description in rows:
+            long_names, short_alias, option_type = _parse_option_decl(decl)
+            table.add_row(long_names, short_alias, option_type, description or '')
+    else:
+        table.add_row('-', '-', '-', 'No entries')
+
+    return Panel(
+        table,
+        title=' Options ',
+        title_align='left',
+        border_style='grey66',
+        box=box.ROUNDED,
+        padding=(0, 1),
+    )
+
+
+class StyledCommand(click.Command):
+    """Click command with styled help output."""
+
+    def _help_options_rows(self, ctx: click.Context) -> list[tuple[str, str]]:
+        return _collect_help_rows(self.get_params(ctx), ctx)
+
+    def get_help(self, ctx: click.Context) -> str:
+        console = Console(width=ctx.terminal_width or 120)
+
+        with console.capture() as capture:
+            _render_usage(console, self.get_usage(ctx))
+
+            help_text = cleandoc(self.help or '').replace('\x08', '')
+            if help_text:
+                console.print(Padding(help_text, (0, 0, 0, 1)))
+
+            console.print(_options_panel(self._help_options_rows(ctx)))
+
+            footer = getattr(self, 'help_footer', None)
+            if footer:
+                console.print(f'\n{footer}')
+
+        return capture.get()
+
+
+class StyledGroup(click.Group):
+    """Click group with Rich help rendering."""
+
+    command_class = StyledCommand
+
+    def _alias_map(self) -> dict[str, list[str]]:
+        """Return canonical-command -> aliases mapping."""
+        return {}
+
+    def _help_options_rows(self, ctx: click.Context) -> list[tuple[str, str]]:
+        return _collect_help_rows(self.get_params(ctx), ctx)
+
+    def _help_commands_rows(self, ctx: click.Context) -> list[tuple[str, str]]:
+        rows: list[tuple[str, str]] = []
+        alias_map = self._alias_map()
+
+        for name in self.list_commands(ctx):
+            cmd = self.get_command(ctx, name)
+            if cmd is None or cmd.hidden:
+                continue
+
+            desc = cmd.get_short_help_str(limit=150)
+            aliases = alias_map.get(name, [])
+            if aliases:
+                quoted = ', '.join(f'`{alias}`' for alias in sorted(aliases))
+                alias_label = 'alias' if len(aliases) == 1 else 'aliases'
+                alias_text = f'{alias_label}: {quoted}'
+                if desc:
+                    desc = f'{desc.rstrip(".")}, {alias_text}'
+                else:
+                    desc = alias_text
+
+            rows.append((name, desc))
+
+        return rows
+
+    def get_help(self, ctx: click.Context) -> str:
+        console = Console(width=ctx.terminal_width or 120)
+
+        with console.capture() as capture:
+            _render_usage(console, self.get_usage(ctx))
+
+            help_text = cleandoc(self.help or '')
+            if help_text:
+                console.print(
+                    Padding(
+                        f'[bright_white]{escape(_single_paragraph(help_text))}[/bright_white]',
+                        (0, 0, 0, 1),
+                    )
+                )
+                console.print()
+
+            console.print(_options_panel(self._help_options_rows(ctx)))
+            console.print()
+            console.print(_section_panel('Commands', self._help_commands_rows(ctx)))
+
+            footer = getattr(self, 'help_footer', None)
+            if footer:
+                console.print(f'\n{footer}')
+
+        return capture.get()
+
+
+class StyledAliasGroup(StyledGroup):
+    """Styled group with command alias support."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._aliases: dict[str, str] = {}
+
+    def add_alias(self, name: str, alias: str) -> None:
+        """Register an alias for an existing command."""
+        self._aliases[alias] = name
+
+    def get_command(self, ctx: click.Context, cmd_name: str):
+        canonical = self._aliases.get(cmd_name, cmd_name)
+        return super().get_command(ctx, canonical)
+
+    def _alias_map(self) -> dict[str, list[str]]:
+        reverse: dict[str, list[str]] = {}
+        for alias, canonical in self._aliases.items():
+            reverse.setdefault(canonical, []).append(alias)
+        return reverse

--- a/autoppia_web_agents_subnet/miner/service.py
+++ b/autoppia_web_agents_subnet/miner/service.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .utils import compute_current_round, compute_next_round, compute_season, detect_github_ref_kind
+from .ui import (
+    console,
+    print_banner,
+    print_success,
+    print_warning,
+    show_chain_state_panel,
+    show_commitment_panel,
+    show_wallet_panel,
+)
+
+DEFAULT_NETUID = 36
+
+
+class MinerCliError(Exception):
+    """Raised for user-facing CLI errors."""
+
+
+@dataclass(frozen=True)
+class CommonOptions:
+    wallet_name: str
+    wallet_hotkey: str
+    subtensor_network: str
+    subtensor_chain_endpoint: str | None
+    netuid: int
+
+
+def _resolve_subtensor_config(options: CommonOptions) -> tuple[str, dict[str, str]]:
+    if options.subtensor_chain_endpoint:
+        endpoint = options.subtensor_chain_endpoint.strip()
+        if endpoint:
+            return endpoint, {"network": endpoint}
+    return options.subtensor_network, {"network": options.subtensor_network}
+
+
+def _validate_submit_inputs(
+    github: str,
+    agent_name: str,
+    agent_image: str,
+    target_round: int | None,
+    season: int | None,
+) -> tuple[str, str, str]:
+    from autoppia_web_agents_subnet.opensource.utils_git import normalize_and_validate_github_url
+
+    normalized, ref = normalize_and_validate_github_url(github, require_ref=True)
+    if normalized is None or not ref:
+        raise MinerCliError(
+            f"Invalid GitHub URL: {github}\n"
+            "       Must be https://github.com/owner/repo/tree/<ref> or /commit/<sha>."
+        )
+
+    stripped_name = agent_name.strip()
+    if not stripped_name:
+        raise MinerCliError("--agent.name must not be empty.")
+
+    if season is not None and season <= 0:
+        raise MinerCliError("--season must be a positive integer.")
+
+    if target_round is not None and target_round <= 0:
+        raise MinerCliError("--target_round must be a positive integer.")
+
+    ref_kind = detect_github_ref_kind(github)
+    github_url = f"{normalized}/{ref_kind}/{ref}"
+    return github_url, stripped_name, (agent_image or "").strip()
+
+
+async def run_submit(
+    *,
+    options: CommonOptions,
+    github: str,
+    agent_name: str,
+    agent_image: str,
+    target_round: int | None,
+    season: int | None,
+) -> None:
+    import bittensor as bt
+    from autoppia_web_agents_subnet.utils.commitments import read_my_plain_json, write_plain_commitment_json
+
+    print_banner()
+    github_url, stripped_name, stripped_image = _validate_submit_inputs(github, agent_name, agent_image, target_round, season)
+
+    wallet = bt.Wallet(name=options.wallet_name, hotkey=options.wallet_hotkey)
+    network_label, subtensor_kwargs = _resolve_subtensor_config(options)
+    show_wallet_panel(wallet, network_label, options.netuid)
+
+    async with bt.AsyncSubtensor(**subtensor_kwargs) as st:
+        with console.status("[bold cyan]Connecting to subtensor...", spinner="dots"):
+            current_block = await st.get_current_block()
+
+        season_number = season if season is not None else compute_season(current_block)
+        target_round_number = target_round if target_round is not None else compute_next_round(current_block, season_number)
+        current_round = compute_current_round(current_block, season_number)
+
+        show_chain_state_panel(current_block, season_number, current_round, target_round_number)
+
+        payload: dict[str, Any] = {
+            "t": "m",
+            "g": github_url,
+            "n": stripped_name,
+            "r": int(target_round_number),
+            "s": int(season_number),
+        }
+        if stripped_image:
+            payload["i"] = stripped_image
+
+        show_commitment_panel(payload, title="Commitment Payload", border_style="blue")
+
+        with console.status("[bold cyan]Submitting commitment on-chain...", spinner="dots"):
+            ok = await write_plain_commitment_json(st, wallet=wallet, data=payload, netuid=options.netuid)
+
+        if not ok:
+            raise MinerCliError("Commitment submission failed.")
+        print_success("Commitment submitted successfully.")
+
+        with console.status("[bold cyan]Verifying on-chain commitment...", spinner="dots"):
+            readback = await read_my_plain_json(st, wallet=wallet, netuid=options.netuid)
+
+        if readback:
+            show_commitment_panel(readback, title="On-Chain Verification", border_style="green")
+        else:
+            print_warning("Could not read back commitment (may take a block to propagate).")
+
+
+async def run_show(*, options: CommonOptions) -> None:
+    import bittensor as bt
+    from autoppia_web_agents_subnet.utils.commitments import read_my_plain_json
+
+    print_banner()
+
+    wallet = bt.Wallet(name=options.wallet_name, hotkey=options.wallet_hotkey)
+    network_label, subtensor_kwargs = _resolve_subtensor_config(options)
+    show_wallet_panel(wallet, network_label, options.netuid)
+
+    async with bt.AsyncSubtensor(**subtensor_kwargs) as st:
+        with console.status("[bold cyan]Connecting to subtensor...", spinner="dots"):
+            current_block = await st.get_current_block()
+
+        season_number = compute_season(current_block)
+        current_round = compute_current_round(current_block, season_number)
+        show_chain_state_panel(current_block, season_number, current_round)
+
+        with console.status("[bold cyan]Reading commitment...", spinner="dots"):
+            commitment = await read_my_plain_json(st, wallet=wallet, netuid=options.netuid)
+
+        if commitment is None:
+            print_warning("No commitment found on-chain for this hotkey.")
+        else:
+            show_commitment_panel(commitment, title="On-Chain Commitment", border_style="green")

--- a/autoppia_web_agents_subnet/miner/ui.py
+++ b/autoppia_web_agents_subnet/miner/ui.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def print_banner() -> None:
+    console.print(
+        Panel(
+            Text("autoppia-miner-cli", style="bold cyan", justify="center"),
+            subtitle="Miner Agent On-Chain Commitment Tool",
+            border_style="bright_blue",
+        )
+    )
+    console.print()
+
+
+def print_error(msg: str) -> None:
+    err_console.print(f"[bold red]ERROR:[/bold red] {msg}")
+
+
+def print_warning(msg: str) -> None:
+    console.print(f"[bold yellow]WARNING:[/bold yellow] {msg}")
+
+
+def print_success(msg: str) -> None:
+    console.print(f"[bold green]OK:[/bold green] {msg}")
+
+
+def _wallet_table(wallet: Any, network_label: str, netuid: int) -> Table:
+    table = Table(show_header=False, border_style="dim", pad_edge=False, box=None)
+    table.add_column("Key", style="bold")
+    table.add_column("Value")
+    table.add_row("Wallet", f"{wallet.name} / {wallet.hotkey_str}")
+    table.add_row("Hotkey", f"{wallet.hotkey.ss58_address}")
+    table.add_row("Network", network_label)
+    table.add_row("Netuid", str(netuid))
+    return table
+
+
+def _chain_info_table(current_block: int, season: int, current_round: int, target_round: int | None = None) -> Table:
+    table = Table(show_header=False, border_style="dim", pad_edge=False, box=None)
+    table.add_column("Key", style="bold")
+    table.add_column("Value")
+    table.add_row("Current block", f"{current_block:,}")
+    table.add_row("Season", str(season))
+    table.add_row("Current round", str(current_round))
+    if target_round is not None:
+        table.add_row("Target round", f"[bold yellow]{target_round}[/bold yellow]")
+    return table
+
+
+def _commitment_detail_table(data: dict[str, Any]) -> Table:
+    field_labels: dict[str, tuple[str, Any]] = {
+        "t": ("Type", lambda v: "miner" if v == "m" else "validator" if v == "v" else str(v)),
+        "g": ("GitHub", str),
+        "n": ("Agent name", str),
+        "r": ("Round", str),
+        "s": ("Season", str),
+        "i": ("Image", str),
+    }
+    table = Table(show_header=False, border_style="dim", pad_edge=False, box=None)
+    table.add_column("Field", style="bold")
+    table.add_column("Value")
+    for key, value in data.items():
+        if key in field_labels:
+            label, fmt = field_labels[key]
+            table.add_row(label, fmt(value))
+        else:
+            table.add_row(key, str(value))
+    return table
+
+
+def show_wallet_panel(wallet: Any, network_label: str, netuid: int) -> None:
+    console.print(Panel(_wallet_table(wallet, network_label, netuid), title="Wallet", border_style="blue"))
+
+
+def show_chain_state_panel(
+    current_block: int,
+    season: int,
+    current_round: int,
+    target_round: int | None = None,
+) -> None:
+    console.print(
+        Panel(
+            _chain_info_table(current_block, season, current_round, target_round),
+            title="Chain State",
+            border_style="blue",
+        )
+    )
+
+
+def show_commitment_panel(data: dict[str, Any], *, title: str, border_style: str) -> None:
+    console.print(Panel(_commitment_detail_table(data), title=title, border_style=border_style))

--- a/autoppia_web_agents_subnet/miner/utils.py
+++ b/autoppia_web_agents_subnet/miner/utils.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from autoppia_web_agents_subnet.utils.env import _env_float, _env_int
+
+BLOCKS_PER_EPOCH = 360
+SEASON_SIZE_EPOCHS = _env_float("SEASON_SIZE_EPOCHS", 280.0, test_default=2)
+ROUND_SIZE_EPOCHS = _env_float("ROUND_SIZE_EPOCHS", 4.0, test_default=0.5)
+MINIMUM_START_BLOCK = _env_int("MINIMUM_START_BLOCK", 7_586_110, test_default=7_586_110)
+
+
+def season_block_length() -> int:
+    return int(BLOCKS_PER_EPOCH * SEASON_SIZE_EPOCHS)
+
+
+def round_block_length() -> int:
+    return int(BLOCKS_PER_EPOCH * ROUND_SIZE_EPOCHS)
+
+
+def compute_season(current_block: int) -> int:
+    if current_block < MINIMUM_START_BLOCK:
+        return 0
+    return int((current_block - MINIMUM_START_BLOCK) // season_block_length()) + 1
+
+
+def compute_season_start_block(season_number: int) -> int:
+    if season_number <= 0:
+        return MINIMUM_START_BLOCK
+    return MINIMUM_START_BLOCK + (season_number - 1) * season_block_length()
+
+
+def compute_current_round(current_block: int, season_number: int) -> int:
+    season_start = compute_season_start_block(season_number)
+    effective = max(current_block, season_start)
+    return int((effective - season_start) // round_block_length()) + 1
+
+
+def compute_next_round(current_block: int, season_number: int) -> int:
+    return compute_current_round(current_block, season_number) + 1
+
+
+def detect_github_ref_kind(raw_url: str) -> str:
+    url = raw_url.strip()
+    if url.startswith("git@github.com:"):
+        path = url[len("git@github.com:") :].strip()
+        segments = [segment for segment in path.split("/") if segment]
+    else:
+        if not url.startswith(("http://", "https://")):
+            url = f"https://{url}"
+        parsed = urlparse(url)
+        segments = [segment for segment in (parsed.path or "").strip("/").split("/") if segment]
+
+    if len(segments) >= 4 and (segments[2] or "").lower() == "commit":
+        return "commit"
+    return "tree"


### PR DESCRIPTION
## Summary
This PR restructures the miner CLI from a single-file implementation into a clearer layered architecture:

- `cli.py`: command entrypoint and option wiring
- `help.py`: styled help rendering
- `service.py`: command business logic and chain operations
- `ui.py`: Rich view/presentation helpers
- `utils.py`: pure utility helpers (round/season math + URL ref-kind helper)

The goal is maintainability and safer future iteration, without changing core CLI workflows.

## Why
The previous implementation mixed:
- command parsing
- business logic
- chain I/O
- UI rendering
- utility math

in one file, which made review, testing, and future feature work harder.

This refactor isolates concerns so each file has a single responsibility.

## Structural changes

### 1) CLI composition
- Migrated to Click command registration with shared common options.
- Kept command surface intact (`submit`, `show`) and existing flag names.
- Added `--version`.

### 2) Service layer
- Extracted submit/show execution flow into `service.py`.
- Centralized user-facing validation and failure boundaries in one place.
- Kept lazy runtime imports for chain dependencies to avoid startup/help side effects.

### 3) UI layer
- Moved all Rich rendering (banner, status messages, panels/tables) to `ui.py`.
- `service.py` now calls UI helpers instead of directly building tables/panels.

### 4) Utilities
- Consolidated round/season helpers and GitHub ref-kind detection in `utils.py`.

## Behavior and compatibility notes
Core command behavior is preserved, with the following intentional improvements:

- Better `--help` UX (styled help output).
- Explicit `--version` support.
- Validation now rejects non-positive `--season` and `--target_round`.
- Commit URL handling preserves `/commit/<sha>` instead of always rewriting to `/tree/<ref>`.
- When `--subtensor.chain_endpoint` is provided, UI shows effective endpoint context.

## Roadmap
- Additional cleanup/refactoring is planned as follow-up PRs, scoped by module/component to keep changes reviewable and low-risk.
- UI/UX grounding and polish toward a production-grade experience (aligned with tools like `btcli`) is planned as a dedicated follow-up track.
- Additional tests (unit + CLI integration/smoke coverage) will be added in follow-up PRs.

## Screenshots
- Before
<img width="1218" height="394" alt="image" src="https://github.com/user-attachments/assets/67e869ac-f80b-4ab6-8424-0098dc4e8074" />

- After
<img width="1358" height="739" alt="image" src="https://github.com/user-attachments/assets/dafd4082-9cb9-4d83-ab64-8d0ffbeb3a12" />
