### PR TITLE
feat: payment-per-eval balance tracking with crash recovery

### DIFF
--- a/autoppia_web_agents_subnet/validator/evaluation/mixin.py
+++ b/autoppia_web_agents_subnet/validator/evaluation/mixin.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import asyncio
 import inspect
 
+import bittensor as bt
+
 from autoppia_web_agents_subnet.validator.evaluation.stateful_cua_eval import evaluate_with_stateful_cua
 from autoppia_web_agents_subnet.validator.evaluation.rewards import calculate_reward_for_task
 from autoppia_web_agents_subnet.validator import config as validator_config
@@ -13,6 +15,12 @@ from autoppia_web_agents_subnet.opensource.utils_git import (
     normalize_and_validate_github_url,
     resolve_remote_ref_commit,
 )
+from autoppia_web_agents_subnet.validator.payment.config import (
+    ALPHA_PER_EVAL,
+    PAYMENT_WALLET_SS58,
+    PAYMENT_CACHE_PATH,
+)
+from autoppia_web_agents_subnet.validator.payment.helpers import increment_consumed_evals
 
 
 class ValidatorEvaluationMixin:
@@ -123,6 +131,31 @@ class ValidatorEvaluationMixin:
                 self.agents_dict[agent.uid] = agent  # type: ignore[attr-defined]
             except Exception:
                 pass
+
+            if bool(PAYMENT_WALLET_SS58) and float(ALPHA_PER_EVAL) > 0:
+                try:
+                    miner_coldkeys = list(getattr(getattr(self, "metagraph", None), "coldkeys", []))
+                    miner_uid = getattr(agent, "uid", None)
+                    if miner_uid is not None and 0 <= int(miner_uid) < len(miner_coldkeys):
+                        ck = str(miner_coldkeys[int(miner_uid)] or "").strip()
+                        if ck:
+                            sm = getattr(self, "season_manager", None)
+                            s_start = int(sm.get_season_start_block(getattr(self, "block", 0) or 0)) if sm else None
+                            s_dur = int(getattr(sm, "season_block_length", 0) or 0) if sm else None
+                            if not s_dur:
+                                from autoppia_web_agents_subnet.validator.config import SEASON_SIZE_EPOCHS
+                                bpe = getattr(getattr(self, "round_manager", None), "BLOCKS_PER_EPOCH", 360) or 360
+                                s_dur = int(float(SEASON_SIZE_EPOCHS) * int(bpe))
+                            netuid = int(getattr(getattr(self, "config", None), "netuid", 36) or 36)
+                            if s_start is not None and s_dur and s_dur > 0:
+                                new_total = increment_consumed_evals(
+                                    ck, payment_address=PAYMENT_WALLET_SS58, netuid=netuid,
+                                    season_start_block=s_start, season_duration_blocks=s_dur,
+                                    count=1, cache_path=PAYMENT_CACHE_PATH,
+                                )
+                                bt.logging.info(f"[payment] Consumed eval incremented uid={miner_uid} ck={ck[:12]}... total={new_total}")
+                except Exception as exc:
+                    bt.logging.warning(f"[payment] Failed to increment consumed evals: {exc}")
 
         agents_evaluated = 0
         while not self.agents_queue.empty():

--- a/autoppia_web_agents_subnet/validator/payment/__init__.py
+++ b/autoppia_web_agents_subnet/validator/payment/__init__.py
@@ -8,6 +8,11 @@ from autoppia_web_agents_subnet.validator.payment.helpers import (
     allowed_evaluations_from_paid_rao,
     get_coldkey_balance,
     get_alpha_sent_by_miner,
+    get_consumed_evals,
+    get_all_consumed_evals,
+    increment_consumed_evals,
+    remaining_evaluations,
+    set_all_consumed_evals,
 )
 
 __all__ = [
@@ -17,5 +22,10 @@ __all__ = [
     "allowed_evaluations_from_paid_rao",
     "get_coldkey_balance",
     "get_alpha_sent_by_miner",
+    "get_consumed_evals",
+    "get_all_consumed_evals",
     "get_paid_alpha_per_coldkey_async",
+    "increment_consumed_evals",
+    "remaining_evaluations",
+    "set_all_consumed_evals",
 ]

--- a/autoppia_web_agents_subnet/validator/payment/cache.py
+++ b/autoppia_web_agents_subnet/validator/payment/cache.py
@@ -1,7 +1,4 @@
-"""
-Local JSON cache for payment scanning.
-Stores cumulative sent-amounts per coldkey and last processed block per season range.
-"""
+"""Local JSON cache for payment scanning."""
 
 from __future__ import annotations
 
@@ -9,9 +6,7 @@ import json
 import os
 import tempfile
 import time
-from typing import Any
-from typing import Dict
-from typing import Tuple
+from typing import Any, Dict, Tuple
 
 CACHE_SCHEMA_VERSION = 1
 
@@ -42,6 +37,7 @@ def _default_entry(
         "season_duration_blocks": int(season_duration_blocks),
         "last_processed_block": int(season_start_block) - 1,
         "totals_by_coldkey": {},
+        "consumed_evals_by_coldkey": {},
         "updated_at_unix": int(time.time()),
     }
 
@@ -115,6 +111,17 @@ class PaymentCacheStore:
                 except Exception:
                     continue
             entry["totals_by_coldkey"] = normalized
+        consumed = existing.get("consumed_evals_by_coldkey", {})
+        if isinstance(consumed, dict):
+            normalized_consumed: Dict[str, int] = {}
+            for ck, count in consumed.items():
+                if not isinstance(ck, str):
+                    continue
+                try:
+                    normalized_consumed[ck] = int(count or 0)
+                except Exception:
+                    continue
+            entry["consumed_evals_by_coldkey"] = normalized_consumed
         try:
             entry["updated_at_unix"] = int(existing.get("updated_at_unix", entry["updated_at_unix"]))
         except Exception:

--- a/autoppia_web_agents_subnet/validator/payment/helpers.py
+++ b/autoppia_web_agents_subnet/validator/payment/helpers.py
@@ -1,30 +1,24 @@
-"""
-Pure helper/check functions for payment-per-eval logic.
-No chain interaction — only math and validation.
-"""
+"""Pure helper/check functions for payment-per-eval logic."""
 
 from __future__ import annotations
 
 import inspect
 import time
-from typing import Any
+from typing import Any, Dict
+
+import bittensor as bt
 
 from autoppia_web_agents_subnet.validator.payment.cache import PaymentCacheStore
 from autoppia_web_agents_subnet.validator.payment.config import (
-    PAYMENT_CACHE_PATH,
-    RAO_PER_ALPHA,
-    PAYMENT_WALLET_SS58,
+    ALPHA_PER_EVAL, PAYMENT_CACHE_PATH, RAO_PER_ALPHA, PAYMENT_WALLET_SS58,
 )
 from autoppia_web_agents_subnet.validator.payment.scanner import (
-    AlphaScanner,
-    get_paid_alpha_per_coldkey_async,
+    AlphaScanner, get_paid_alpha_per_coldkey_async,
 )
 
 
 def allowed_evaluations_from_paid_rao(paid_rao: int, alpha_per_eval: float) -> int:
-    """
-    Number of evaluations allowed for a given paid amount (rao) and cost per eval (alpha).
-    """
+    """Number of evaluations allowed for a given paid amount (rao) and cost per eval (alpha)."""
     if paid_rao <= 0 or alpha_per_eval <= 0:
         return 0
     rao_per_eval = int(alpha_per_eval * RAO_PER_ALPHA)
@@ -36,19 +30,13 @@ def allowed_evaluations_from_paid_rao(paid_rao: int, alpha_per_eval: float) -> i
 async def get_alpha_sent_by_miner(
     coldkey: str,
     *,
-    payment_address: str | None = None,
-    netuid: int = 36,
-    from_block: int | None = None,
-    to_block: int | None = None,
+    payment_address: str | None = None, netuid: int = 36,
+    from_block: int | None = None, to_block: int | None = None,
     subtensor: Any = None,
-    season_start_block: int | None = None,
-    season_duration_blocks: int | None = None,
+    season_start_block: int | None = None, season_duration_blocks: int | None = None,
     cache_path: str | None = None,
 ) -> int:
-    """
-    Return total amount_rao that coldkey sent to the payment address in the optional block range.
-    Uses AlphaScanner internally. subtensor is required; payment_address defaults to PAYMENT_WALLET_SS58.
-    """
+    """Return total amount_rao that coldkey sent to the payment address in the given block range."""
     if subtensor is None:
         return 0
     addr = (payment_address or "").strip() or PAYMENT_WALLET_SS58
@@ -58,7 +46,6 @@ async def get_alpha_sent_by_miner(
     if not ck:
         return 0
 
-    # If a season range is provided, use cache to process only new blocks.
     if season_start_block is not None and season_duration_blocks is not None:
         try:
             season_start = int(season_start_block)
@@ -99,8 +86,6 @@ async def get_alpha_sent_by_miner(
                 totals = entry.get("totals_by_coldkey", {})
                 if not isinstance(totals, dict):
                     totals = {}
-
-                # First run for a season backfills from season start. Afterwards, only new blocks are scanned.
                 if exists:
                     next_block = int(entry.get("last_processed_block", season_start - 1)) + 1
                     if from_block is not None:
@@ -140,7 +125,6 @@ async def get_alpha_sent_by_miner(
 
                 return int(totals.get(ck, 0) or 0)
             except Exception:
-                # Cache is an optimization; if it fails, continue with direct scan.
                 pass
 
     scanner = AlphaScanner(subtensor)
@@ -150,18 +134,13 @@ async def get_alpha_sent_by_miner(
 async def get_coldkey_balance(
     coldkey: str,
     *,
-    payment_address: str | None = None,
-    netuid: int = 36,
-    from_block: int | None = None,
-    to_block: int | None = None,
+    payment_address: str | None = None, netuid: int = 36,
+    from_block: int | None = None, to_block: int | None = None,
     subtensor: Any = None,
-    season_start_block: int | None = None,
-    season_duration_blocks: int | None = None,
+    season_start_block: int | None = None, season_duration_blocks: int | None = None,
     cache_path: str | None = None,
 ) -> int:
-    """
-    Compatibility wrapper: returns total sent amount in rao for a coldkey.
-    """
+    """Compatibility wrapper: returns total sent amount in rao for a coldkey."""
     return await get_alpha_sent_by_miner(
         coldkey,
         payment_address=payment_address,
@@ -173,3 +152,131 @@ async def get_coldkey_balance(
         season_duration_blocks=season_duration_blocks,
         cache_path=cache_path,
     )
+
+
+
+def _load_cache_entry(
+    payment_address: str, netuid: int,
+    season_start_block: int, season_duration_blocks: int,
+    cache_path: str | None = None,
+) -> tuple[PaymentCacheStore, Dict[str, Any], bool]:
+    """Load a cache entry; returns (store, entry, existed)."""
+    store = PaymentCacheStore(cache_path or PAYMENT_CACHE_PATH)
+    entry, existed = store.load_entry(
+        payment_address=payment_address, netuid=netuid,
+        season_start_block=season_start_block, season_duration_blocks=season_duration_blocks,
+    )
+    return store, entry, existed
+
+
+def get_consumed_evals(
+    coldkey: str, *,
+    payment_address: str | None = None, netuid: int = 36,
+    season_start_block: int, season_duration_blocks: int,
+    cache_path: str | None = None,
+) -> int:
+    """Return the number of evaluations consumed by *coldkey* in the current season."""
+    addr = (payment_address or "").strip() or PAYMENT_WALLET_SS58
+    if not addr:
+        return 0
+    ck = (coldkey or "").strip()
+    if not ck:
+        return 0
+    try:
+        _, entry, _ = _load_cache_entry(addr, netuid, season_start_block, season_duration_blocks, cache_path)
+        return int(entry.get("consumed_evals_by_coldkey", {}).get(ck, 0) or 0)
+    except Exception:
+        return 0
+
+
+def increment_consumed_evals(
+    coldkey: str, *,
+    payment_address: str | None = None, netuid: int = 36,
+    season_start_block: int, season_duration_blocks: int,
+    count: int = 1, cache_path: str | None = None,
+) -> int:
+    """Increment consumed evaluations for *coldkey* and persist. Returns new total."""
+    addr = (payment_address or "").strip() or PAYMENT_WALLET_SS58
+    if not addr:
+        return 0
+    ck = (coldkey or "").strip()
+    if not ck:
+        return 0
+    try:
+        store, entry, _ = _load_cache_entry(addr, netuid, season_start_block, season_duration_blocks, cache_path)
+        consumed = entry.get("consumed_evals_by_coldkey", {})
+        if not isinstance(consumed, dict):
+            consumed = {}
+        new_total = int(consumed.get(ck, 0) or 0) + max(0, int(count))
+        consumed[ck] = new_total
+        entry["consumed_evals_by_coldkey"] = consumed
+        entry["updated_at_unix"] = int(time.time())
+        store.save_entry(
+            payment_address=addr, netuid=netuid,
+            season_start_block=season_start_block, season_duration_blocks=season_duration_blocks,
+            entry=entry,
+        )
+        return new_total
+    except Exception:
+        return 0
+
+
+def get_all_consumed_evals(
+    *, payment_address: str | None = None, netuid: int = 36,
+    season_start_block: int, season_duration_blocks: int,
+    cache_path: str | None = None,
+) -> Dict[str, int]:
+    """Return the full consumed_evals_by_coldkey map for this season."""
+    addr = (payment_address or "").strip() or PAYMENT_WALLET_SS58
+    if not addr:
+        return {}
+    try:
+        _, entry, _ = _load_cache_entry(addr, netuid, season_start_block, season_duration_blocks, cache_path)
+        consumed = entry.get("consumed_evals_by_coldkey", {})
+        if not isinstance(consumed, dict):
+            return {}
+        return {str(k): int(v or 0) for k, v in consumed.items()}
+    except Exception:
+        return {}
+
+
+def set_all_consumed_evals(
+    consumed_map: Dict[str, int], *,
+    payment_address: str | None = None, netuid: int = 36,
+    season_start_block: int, season_duration_blocks: int,
+    cache_path: str | None = None,
+) -> None:
+    """Overwrite the consumed_evals_by_coldkey map (used for crash recovery)."""
+    addr = (payment_address or "").strip() or PAYMENT_WALLET_SS58
+    if not addr:
+        return
+    try:
+        store, entry, _ = _load_cache_entry(addr, netuid, season_start_block, season_duration_blocks, cache_path)
+        normalized: Dict[str, int] = {}
+        for ck, count in (consumed_map or {}).items():
+            if not isinstance(ck, str):
+                continue
+            try:
+                normalized[ck] = max(0, int(count or 0))
+            except Exception:
+                continue
+        entry["consumed_evals_by_coldkey"] = normalized
+        entry["updated_at_unix"] = int(time.time())
+        store.save_entry(
+            payment_address=addr, netuid=netuid,
+            season_start_block=season_start_block, season_duration_blocks=season_duration_blocks,
+            entry=entry,
+        )
+    except Exception:
+        pass
+
+
+def remaining_evaluations(
+    paid_rao: int, consumed_evals: int, alpha_per_eval: float | None = None,
+) -> int:
+    """Compute remaining evaluations: allowed_from_payment - consumed."""
+    cost = alpha_per_eval if alpha_per_eval is not None else ALPHA_PER_EVAL
+    if cost <= 0:
+        return 999_999  # Payment disabled — unlimited evaluations.
+    allowed = allowed_evaluations_from_paid_rao(paid_rao, cost)
+    return max(0, allowed - max(0, int(consumed_evals)))

--- a/autoppia_web_agents_subnet/validator/round_start/mixin.py
+++ b/autoppia_web_agents_subnet/validator/round_start/mixin.py
@@ -28,6 +28,13 @@ from autoppia_web_agents_subnet.validator.config import (
     EVALUATION_COOLDOWN_ZERO_SCORE_BADNESS,
 )
 from autoppia_web_agents_subnet.utils.commitments import read_all_plain_commitments
+from autoppia_web_agents_subnet.validator.payment.config import (
+    ALPHA_PER_EVAL, PAYMENT_WALLET_SS58, PAYMENT_CACHE_PATH,
+)
+from autoppia_web_agents_subnet.validator.payment.helpers import (
+    get_alpha_sent_by_miner, get_all_consumed_evals, get_consumed_evals,
+    remaining_evaluations, set_all_consumed_evals,
+)
 
 
 def _commits_match(a: str | None, b: str | None) -> bool:
@@ -361,6 +368,81 @@ class ValidatorRoundStartMixin:
             f"{len(commitment_by_uid)} miner commitments matched to UIDs"
         )
 
+        # Crash recovery: restore consumed evals from on-chain commitment "e" field.
+        if bool(PAYMENT_WALLET_SS58) and float(ALPHA_PER_EVAL) > 0:
+            try:
+                my_commitment = all_commitments.get(self.wallet.hotkey.ss58_address)
+                if isinstance(my_commitment, dict) and "e" in my_commitment:
+                    sm_cr = getattr(self, "season_manager", None)
+                    s_start_cr = int(sm_cr.get_season_start_block(self.block)) if sm_cr else None
+                    s_dur_cr = int(getattr(sm_cr, "season_block_length", 0) or 0) if sm_cr else None
+                    if not s_dur_cr:
+                        from autoppia_web_agents_subnet.validator.config import SEASON_SIZE_EPOCHS
+                        bpe = getattr(getattr(self, "round_manager", None), "BLOCKS_PER_EPOCH", 360) or 360
+                        s_dur_cr = int(float(SEASON_SIZE_EPOCHS) * int(bpe))
+                    if s_start_cr is not None and s_dur_cr and s_dur_cr > 0:
+                        cache_kw = dict(payment_address=PAYMENT_WALLET_SS58, netuid=netuid,
+                                        season_start_block=s_start_cr, season_duration_blocks=s_dur_cr,
+                                        cache_path=PAYMENT_CACHE_PATH)
+                        local_consumed = get_all_consumed_evals(**cache_kw)
+                        onchain_consumed = my_commitment["e"]
+                        if isinstance(onchain_consumed, dict) and not local_consumed:
+                            set_all_consumed_evals(onchain_consumed, **cache_kw)
+                            bt.logging.info(f"[payment] Restored {len(onchain_consumed)} consumed eval entries from on-chain")
+                        elif isinstance(onchain_consumed, dict) and local_consumed:
+                            merged, updated = dict(local_consumed), False
+                            for ck, count in onchain_consumed.items():
+                                if not isinstance(ck, str):
+                                    continue
+                                try:
+                                    onchain_val = int(count or 0)
+                                except Exception:
+                                    continue
+                                if onchain_val > int(merged.get(ck, 0) or 0):
+                                    merged[ck] = onchain_val
+                                    updated = True
+                            if updated:
+                                set_all_consumed_evals(merged, **cache_kw)
+                                bt.logging.info("[payment] Merged consumed evals from on-chain (some on-chain values were higher)")
+            except Exception as exc:
+                bt.logging.warning(f"[payment] Consumed evals crash recovery failed: {exc}")
+
+        # Pre-compute per-coldkey remaining evaluations for payment gating.
+        payment_enabled = bool(PAYMENT_WALLET_SS58) and float(ALPHA_PER_EVAL) > 0
+        remaining_evals_by_coldkey: dict[str, int] = {}
+        if payment_enabled:
+            try:
+                sm = getattr(self, "season_manager", None)
+                s_start = int(sm.get_season_start_block(self.block)) if sm else None
+                s_duration = int(getattr(sm, "season_block_length", 0) or 0) if sm else None
+                if not s_duration:
+                    from autoppia_web_agents_subnet.validator.config import SEASON_SIZE_EPOCHS
+                    bpe = getattr(getattr(self, "round_manager", None), "BLOCKS_PER_EPOCH", 360) or 360
+                    s_duration = int(float(SEASON_SIZE_EPOCHS) * int(bpe))
+                if s_start is not None and s_duration and s_duration > 0:
+                    unique_coldkeys: set[str] = set()
+                    for uid in candidate_uids:
+                        if 0 <= uid < len(coldkeys):
+                            ck = str(coldkeys[uid] or "").strip()
+                            if ck:
+                                unique_coldkeys.add(ck)
+                    pay_kw = dict(payment_address=PAYMENT_WALLET_SS58, netuid=netuid,
+                                  season_start_block=s_start, season_duration_blocks=s_duration,
+                                  cache_path=PAYMENT_CACHE_PATH)
+                    for ck in unique_coldkeys:
+                        try:
+                            paid_rao = await get_alpha_sent_by_miner(ck, subtensor=self.subtensor, **pay_kw)
+                            consumed = get_consumed_evals(ck, **pay_kw)
+                            remaining_evals_by_coldkey[ck] = remaining_evaluations(paid_rao, consumed)
+                        except Exception as exc:
+                            bt.logging.warning(f"[collect_commitments] Payment check failed for {ck[:12]}...: {exc}")
+                            remaining_evals_by_coldkey[ck] = 999_999  # Fail-open
+                    paid_count = sum(1 for r in remaining_evals_by_coldkey.values() if r > 0)
+                    bt.logging.info(f"[collect_commitments] Payment balance: {len(unique_coldkeys)} coldkeys scanned, {paid_count} have remaining evals")
+            except Exception as exc:
+                bt.logging.warning(f"[collect_commitments] Payment balance setup failed: {exc}; proceeding without gating")
+                payment_enabled = False
+
         # ── Process each candidate ────────────────────────────────────────
         new_agents_count = 0
         current_round = int(getattr(self.round_manager, "round_number", 0) or 0)
@@ -378,6 +460,16 @@ class ValidatorRoundStartMixin:
         cooldown_skip_count = 0
         unchanged_commit_skip_count = 0
         queued_for_eval_count = 0
+        payment_skip_count = 0
+
+        def _check_payment_balance(uid: int) -> bool:
+            if not payment_enabled:
+                return True
+            ck = str(coldkeys[uid] or "").strip() if 0 <= uid < len(coldkeys) else ""
+            if not ck:
+                return True
+            remaining = remaining_evals_by_coldkey.get(ck)
+            return remaining is None or remaining > 0
 
         for uid in candidate_uids:
             commitment = commitment_by_uid.get(uid)
@@ -395,6 +487,10 @@ class ValidatorRoundStartMixin:
                         best_score_ever=getattr(self, "_best_score_ever", None),
                         handshake_responded=False,
                     ):
+                        if not _check_payment_balance(uid):
+                            bt.logging.info(f"[collect_commitments] Skipping uid={uid} (pending restore): no remaining paid evals")
+                            payment_skip_count += 1
+                            continue
                         pending_info = AgentInfo(
                             uid=uid,
                             agent_name=existing.pending_agent_name or existing.agent_name,
@@ -634,12 +730,24 @@ class ValidatorRoundStartMixin:
                     cooldown_skip_count += 1
                     continue
 
+                if not _check_payment_balance(uid):
+                    bt.logging.info(f"[collect_commitments] Skipping uid={uid} (changed commit): no remaining paid evals")
+                    payment_skip_count += 1
+                    continue
                 self.agents_queue.put(agent_info)
                 new_agents_count += 1
                 queued_for_eval_count += 1
                 continue
 
-            # New uid: track it immediately and enqueue for evaluation.
+            if not _check_payment_balance(uid):
+                bt.logging.info(f"[collect_commitments] Skipping uid={uid} (new miner): no remaining paid evals")
+                payment_skip_count += 1
+                agent_info.score = 0.0
+                agent_info.evaluated = True
+                self.agents_dict[uid] = agent_info
+                if self.round_manager.round_number == 1:
+                    self.agents_on_first_handshake.append(uid)
+                continue
             self.agents_dict[uid] = agent_info
             self.agents_queue.put(agent_info)
             if self.round_manager.round_number == 1:
@@ -659,6 +767,7 @@ class ValidatorRoundStartMixin:
             f"repo_cap_skip={repo_cap_skip_count} "
             f"cooldown_skip={cooldown_skip_count} "
             f"unchanged_commit={unchanged_commit_skip_count} "
+            f"payment_skip={payment_skip_count} "
             f"new_agents={new_agents_count}"
         )
 

--- a/autoppia_web_agents_subnet/validator/settlement/consensus.py
+++ b/autoppia_web_agents_subnet/validator/settlement/consensus.py
@@ -18,6 +18,10 @@ from autoppia_web_agents_subnet.utils.ipfs_client import add_json_async, get_jso
 from autoppia_web_agents_subnet.utils.log_colors import ipfs_tag, consensus_tag
 from autoppia_web_agents_subnet.validator.round_manager import RoundPhase
 from autoppia_web_agents_subnet.platform.client import compute_season_number
+from autoppia_web_agents_subnet.validator.payment.config import (
+    ALPHA_PER_EVAL, PAYMENT_WALLET_SS58, PAYMENT_CACHE_PATH,
+)
+from autoppia_web_agents_subnet.validator.payment.helpers import get_all_consumed_evals
 
 
 def _safe_season_number(self, current_block: int) -> int:
@@ -144,6 +148,30 @@ async def publish_round_snapshot(
         "c": str(cid),
         "p": 0,  # phase placeholder for future extensions
     }
+
+    # Include consumed evaluations in on-chain commitment for crash recovery.
+    if bool(PAYMENT_WALLET_SS58) and float(ALPHA_PER_EVAL) > 0:
+        try:
+            sm = getattr(self, "season_manager", None)
+            s_start = int(sm.get_season_start_block(current_block)) if sm else None
+            s_dur = int(getattr(sm, "season_block_length", 0) or 0) if sm else None
+            if not s_dur:
+                from autoppia_web_agents_subnet.validator.config import SEASON_SIZE_EPOCHS
+                bpe = getattr(getattr(self, "round_manager", None), "BLOCKS_PER_EPOCH", 360) or 360
+                s_dur = int(float(SEASON_SIZE_EPOCHS) * int(bpe))
+            netuid = int(getattr(self.config, "netuid", 36) or 36)
+            if s_start is not None and s_dur and s_dur > 0:
+                consumed = get_all_consumed_evals(
+                    payment_address=PAYMENT_WALLET_SS58, netuid=netuid,
+                    season_start_block=s_start, season_duration_blocks=s_dur,
+                    cache_path=PAYMENT_CACHE_PATH,
+                )
+                compact = {k: v for k, v in consumed.items() if v > 0}
+                if compact:
+                    commit_payload["e"] = compact
+                    bt.logging.info(f"[payment] Including {len(compact)} consumed eval entries in commitment")
+        except Exception as exc:
+            bt.logging.warning(f"[payment] Failed to include consumed evals in commitment: {exc}")
 
     try:
         bt.logging.info(


### PR DESCRIPTION
## Summary

Implements the payment-per-evaluation mechanism for SN36. Miners transfer alpha tokens from their coldkey to the validator's payment wallet (`PAYMENT_WALLET_SS58`). Validators track cumulative transfers on-chain, compute how many evaluations each miner has paid for (`paid_rao / (ALPHA_PER_EVAL * RAO_PER_ALPHA)`), and deduct from that balance after each evaluation. When a miner's balance reaches zero, they are skipped in the evaluation queue until they pay more.

### Payment flow
1. **Round start** (`round_start/mixin.py`): Scans alpha transfers per candidate coldkey, loads consumed eval counts from local cache, computes remaining balance per miner. Miners with zero remaining evals are skipped at all three queue insertion points (pending restore, changed commit, new miner).
2. **Evaluation** (`evaluation/mixin.py`): After each agent evaluation completes, increments the consumed eval counter for that miner's coldkey in the local JSON cache.
3. **Settlement** (`consensus.py`): Writes the full consumed evals map (`"e"` field) into the on-chain commitment alongside the IPFS CID, enabling crash recovery.

### Crash recovery
On validator restart, the local cache may be empty. During `_collect_miner_commitments`, the validator reads its own on-chain commitment's `"e"` field and restores consumed evals to the local cache. If both local and on-chain data exist, a max-merge strategy is used to avoid losing counts from either source.

### Design decisions
- **Fail-open**: If any payment check errors (chain RPC failure, cache corruption, missing coldkey), the miner is allowed through rather than blocked. This prevents payment infrastructure issues from halting evaluations.
- **Season-scoped**: Consumed evals are keyed by `(payment_address, netuid, season_start_block, season_duration_blocks)`, so they reset naturally each season.
- **Dual-layer persistence**: Local JSON cache for fast reads/writes during normal operation; on-chain commitment for durability across restarts.
- **Opt-in**: All payment gating is disabled when `ALPHA_PER_EVAL <= 0` or `PAYMENT_WALLET_SS58` is unset, preserving backward compatibility.
- **1 coldkey = 1 miner**: Payment balance is tracked per coldkey, enforcing the SN36 rule that each coldkey maps to one miner.

### Changed files
| File | Change |
|------|--------|
| `payment/cache.py` | Added `consumed_evals_by_coldkey` field to cache entries and deserialization in `load_entry` |
| `payment/helpers.py` | New functions: `get_consumed_evals`, `increment_consumed_evals`, `get_all_consumed_evals`, `set_all_consumed_evals`, `remaining_evaluations`, `_load_cache_entry` |
| `payment/__init__.py` | Exported new helper functions |
| `round_start/mixin.py` | Crash recovery from on-chain `"e"` field, pre-compute payment balances per coldkey, gate evaluation queue at 3 insertion points, removed unused `PAYMENT_SUBNET_ID` import |
| `evaluation/mixin.py` | Increment consumed evals in `_finalize_agent` after each evaluation |
| `settlement/consensus.py` | Write non-zero consumed evals map to on-chain commitment |
