### PR TITLE
fix: correct IPFS client import in show_commitments script

### DIFF
--- a/scripts/validator/reporting/show_commitments.py
+++ b/scripts/validator/reporting/show_commitments.py
@@ -15,7 +15,7 @@ from rich import box  # type: ignore
 from bittensor import AsyncSubtensor  # type: ignore
 
 from autoppia_web_agents_subnet.utils.commitments import read_all_plain_commitments
-from autoppia_web_agents_subnet.utils.ipfs_client import IPFSError, aget_json
+from autoppia_web_agents_subnet.utils.ipfs_client import IPFSError, get_json_async
 from autoppia_web_agents_subnet.validator.config import (
     MINIMUM_START_BLOCK,
     IPFS_API_URL,
@@ -122,7 +122,7 @@ async def _fetch_payload(
     gateways: Optional[Sequence[str]],
 ) -> Tuple[Optional[Dict[str, Any]], Optional[str], Optional[str]]:
     try:
-        payload, _, sha_hex = await aget_json(cid, api_url=api_url, gateways=gateways)
+        payload, _, sha_hex = await get_json_async(cid, api_url=api_url, gateways=gateways)
         if isinstance(payload, dict):
             return payload, sha_hex, None
         return None, None, "payload is not a dict"


### PR DESCRIPTION
## Summary
Fixes `ImportError` when running `show_commitments.py`. The IPFS client function was renamed from `aget_json` to `get_json_async` in `ipfs_client.py`, but this script still used the old name.

## Changes
- Updated import: `aget_json` → `get_json_async`
- Updated call site in `_fetch_payload()`

## Verification
The script now loads and runs without ImportError.
