### PR TITLE
fix: return res in except block of dendrite_with_retries

### DIFF
--- a/autoppia_web_agents_subnet/utils/dendrite.py
+++ b/autoppia_web_agents_subnet/utils/dendrite.py
@@ -49,3 +49,4 @@ async def dendrite_with_retries(
 
     except Exception as e:
         bt.logging.error(f"Error while sending synapse with dendrite with retries {e}")
+        return res


### PR DESCRIPTION
Fixes #49

## Problem

`dendrite_with_retries` is typed as `-> list[T | None]` but the `except` block ends without a `return` statement, so the function implicitly returns `None` on any exception. Any caller that iterates or unpacks the result then raises a secondary `TypeError`, hiding the original error.

## Fix

Added `return res` in the `except` handler. This returns the partially-filled result list (with `None` entries for axons that were not reached), allowing callers to inspect partial results and handle failures gracefully rather than crashing.

## Testing

- 97 tests pass across `tests/utils/`, `tests/base/`, and `tests/test_protocol.py`
- Tests requiring `docker` module skipped (pre-existing environment limitation, unrelated to this change)